### PR TITLE
MOB-42549: Add initializers for better module recognition

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the config directory a Python package

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the tools directory a Python package


### PR DESCRIPTION
Without this files when importing modules from tools or config, the build stage fails (e.g: when multiple tools)