### PR TITLE
MOB-43253: Migrate base docker image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
             arch: amd64
           # TODO: Uncomment when repository is public
           # - os: ubuntu-24.04-arm
-          #   name: linux-arm
+          #   name: linux
           #   arch: arm64
           - os: windows-latest  
             name: windows
@@ -32,8 +32,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v4
-    - name: Build binary
+    
+    - name: Build binary (Linux in Ubuntu 25.10 container)
+      if: matrix.name == 'linux'
+      shell: bash
+      run: |
+        # Docker container with Ubuntu 25.10 and build the binary inside it
+        docker run --rm \
+          -v "$PWD:/workspace" \
+          -w /workspace \
+          ubuntu:25.10 \
+          bash -c "
+            set -e
+            echo 'Setting up Ubuntu 25.10 build environment...'
+            
+            apt-get update -y
+            apt-get install -y curl python3 python3-pip python3-venv binutils
+            
+            # Install uv (Python package manager)
+            curl -LsSf https://astral.sh/uv/install.sh | sh
+            export PATH=\"\$HOME/.local/bin:\$PATH\"
+            
+            echo 'Building binary with uv...'
+            uv sync
+            uv run build.py
+            
+            echo 'Build completed. Checking output:'
+            ls -la dist/
+          "
+    
+    - name: Setup uv for Windows/macOS
+      if: matrix.name != 'linux'
+      uses: astral-sh/setup-uv@v4
+    
+    - name: Build binary (Windows/macOS native)
+      if: matrix.name != 'linux'
       shell: bash
       run: |
         uv sync

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:24.04
+FROM ubuntu:25.10
 
 
 WORKDIR /app
@@ -21,7 +21,7 @@ WORKDIR /app
 RUN apt-get update -y && apt-get upgrade -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Create a non-root user
-RUN groupadd -r appgroup && useradd -r -g appgroup appuser
+RUN groupadd -r bzm-mcp && useradd -r -g bzm-mcp bzm-mcp
 
 ARG TARGETPLATFORM
 
@@ -39,10 +39,10 @@ RUN case "${TARGETPLATFORM}" in \
 
     
 RUN chmod +x ./bzm-mcp && \
-    chown appuser:appgroup ./bzm-mcp
+    chown bzm-mcp:bzm-mcp ./bzm-mcp
 
 # Switch to non-root user
-USER appuser
+USER bzm-mcp
 
 # Command to run the application
 ENTRYPOINT ["./bzm-mcp"]


### PR DESCRIPTION
The migration not only forces the Dockerfile to get changed but also the building stage for the binary has to work in the context of the new base image.

Problem here is that github does not have an ubuntu runner with version
25. Therefore it requires to use a docker in docker in the pipeline.