### PR TITLE
MOB-43221: Configure test locations

### DIFF
--- a/models/performance_test.py
+++ b/models/performance_test.py
@@ -15,13 +15,25 @@ class PerformanceTestObject:
     @staticmethod
     def _extract_override_execution(test_data: Dict[str, Any]) -> Dict[str, Any]:
         execution_config = {}
-        for param in ["iterations", "concurrency", "hold-for", "ramp-up", "steps", "executor"]:
+        concurrency = int(test_data["concurrency"]) if "concurrency" in test_data and test_data["concurrency"] else 1
+        for param in ["iterations", "concurrency", "hold-for", "ramp-up", "steps", "executor", "locations"]:
             if param in test_data:
                 match param:
                     case "ramp-up":
                         execution_config["rampUp"] = test_data[param]
                     case "hold-for":
                         execution_config["holdFor"] = test_data[param]
+                    case "locations":
+                        locations_percents = {}
+                        locations_concurrency = {}
+                        for location in test_data[param]:
+                            location_kv = location.split("=")
+                            location_percent = int(location_kv[1])
+                            locations_percents[location_kv[0]] = location_percent
+                            locations_concurrency[location_kv[0]] = int(location_percent * concurrency / 100)
+
+                        execution_config["locations"] = locations_concurrency
+                        execution_config["locationsPercents"] = locations_percents
                     case _:
                         execution_config[param] = test_data[param]
         return execution_config

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -262,6 +262,7 @@ def register(mcp, token: Optional[BzmToken]):
                 ramp-up (str): The length of time the test will take to ramp-up to full concurrency. Values can be provided in m (minutes) only. Can be empty.
                 steps (int, default=1): The number of ramp-up steps. Can be empty.
                 executor (str, default=jmeter): The script type you are running. Includes the following options: (gatling,grinder,jmeter,locust,pbench,selenium,siege).
+                locations (list[str]): List of locations with their percentage distribution of user load in a key value format "location_id=percent_value". Example: ["us-east4-a=25", "us-east1-b=25", "us-west1-a=25", "us-central1-a=25"]
         - upload_assets: Upload main script test as well as multiple related assets to a test. Supports .zip, .csv, .jmx, .yaml and other file types.
             args(dict): Dictionary with the following required parameters:
                 test_id (int): The id of the test to upload assets to.


### PR DESCRIPTION
https://perforce.atlassian.net/browse/MOB-43221

Location support has been added.
In the Blazemeter UI, it is configured based on load distribution, not by the number of users.
While the Blazemeter API indicates that one location system or the other must be configured, in practice, it appears that both must be configured.
This way, the percentages are configured and the users are calculated in the other list.

It was discovered that the current configuration implementation does not support updating configurations.
This is not addressed in this ticket, but it has been reported for further resolution.

This PR it's based on https://github.com/Blazemeter/bzm-mcp/pull/16
First integrate that PR on main to see only the actual changes of this PR.


