### PR TITLE
Mob 45513 improve anomaly detection tool

### DIFF
--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -21,6 +21,7 @@ from models.execution import (
     SummaryReport, SummaryReportMetrics,
     RequestStatsReport, RequestStatMetrics,
     ErrorReport, LabelErrors, HttpError, AssertionError, FailedEmbeddedResource, FailedUrl,
+    AffectedKpi,
     AffectedLabel,
     AnomalyDetail,
     AnomalyDetectionReport,
@@ -540,6 +541,29 @@ def _collect_affected_labels(affected_names: List[str], anomalies_raw: Any) -> L
     return out
 
 
+def _collect_kpi_affected(anomalies_raw: Any) -> tuple[List[AffectedKpi], dict[str, int]]:
+    """Distinct KPIs from anomaly rows with incremental kpi_ref_id; returns list and kpi_id -> kpi_ref_id lookup."""
+    rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
+    out: List[AffectedKpi] = []
+    seen: set[str] = set()
+    for row in rows.values():
+        if not isinstance(row, dict):
+            continue
+        kid = str(row.get("kpi") or "")
+        if not kid or kid in seen:
+            continue
+        seen.add(kid)
+        out.append(
+            AffectedKpi(
+                kpi_ref_id=len(out) + 1,
+                kpi_id=kid,
+                kpi_name=_kpi_code_to_display_name(kid),
+            )
+        )
+    lookup = {item.kpi_id: item.kpi_ref_id for item in out}
+    return out, lookup
+
+
 def _get_anomalies_detection_context() -> str:
     """Context for interpreting anomaly stats and routing the LLM to skills."""
     return (
@@ -552,7 +576,8 @@ def _get_anomalies_detection_context() -> str:
         "- anomaly_count: Total anomalies when statistics are available; 0 means none detected. "
         "Null only when statistics_unavailable (unknown to this tool).\n"
         "- affected_labels: Distinct labels with ref_id, label_id and label_name that had at least one anomaly.\n"
-        "- anomalies: Each row is one anomaly: ref_id, kpi_name, start_time/end_time (ISO 8601), "
+        "- kpi_affected: Distinct KPIs with kpi_ref_id, kpi_id (API key) and kpi_name (human-readable).\n"
+        "- anomalies: Each row is one anomaly: ref_id (label), kpi_ref_id (KPI), start_time/end_time (ISO 8601), "
         "max_spike_height (spike severity for that KPI in that window).\n"
         "- statistics_unavailable_reason: Human-readable explanation when details cannot be shown.\n\n"
         "INTERPRETATION:\n"
@@ -588,6 +613,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
                 anomaly_detection_status="statistics_unavailable",
                 anomaly_count=None,
                 affected_labels=[],
+                kpi_affected=[],
                 anomalies=[],
                 statistics_unavailable_reason=(
                     "BlazeMeter returned no anomaly statistics for this execution. "
@@ -608,6 +634,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
                 anomaly_detection_status="statistics_unavailable",
                 anomaly_count=None,
                 affected_labels=[],
+                kpi_affected=[],
                 anomalies=[],
                 statistics_unavailable_reason=(
                     "Unexpected anomaly statistics payload; could not parse structured anomaly data."
@@ -624,6 +651,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
     anomalies_raw = payload.get("anomalies")
     affected_names = [str(x) for x in affected]
     affected_labels = _collect_affected_labels(affected_names, anomalies_raw)
+    kpi_affected, kpi_lookup = _collect_kpi_affected(anomalies_raw)
 
     details: List[AnomalyDetail] = []
     ref_lookup = {item.label_id: item.ref_id for item in affected_labels if item.label_id}
@@ -633,16 +661,17 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
         for _key, row in anomalies_raw.items():
             if not isinstance(row, dict):
                 continue
-            kpi = row.get("kpi") or ""
+            kpi = str(row.get("kpi") or "")
             st = row.get("startTime")
             en = row.get("endTime")
             lid = str(row.get("labelId", ""))
             lname = str(row.get("labelName", ""))
             ref_id = (ref_lookup.get(lid) or ref_lookup.get(lname)) or 0
+            kpi_ref_id = kpi_lookup.get(kpi) or 0
             details.append(
                 AnomalyDetail(
                     ref_id=ref_id,
-                    kpi_name=_kpi_code_to_display_name(kpi),
+                    kpi_ref_id=kpi_ref_id,
                     start_time=get_date_time_iso(int(st)) if st is not None else None,
                     end_time=get_date_time_iso(int(en)) if en is not None else None,
                     max_spike_height=float(row.get("maxSpikeHeight", 0) or 0),
@@ -666,6 +695,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             anomaly_detection_status=status,
             anomaly_count=count,
             affected_labels=affected_labels,
+            kpi_affected=kpi_affected,
             anomalies=details,
             statistics_unavailable_reason=None,
             context=_get_anomalies_detection_context(),

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -488,16 +488,18 @@ def _get_error_report_context() -> str:
     )
 
 
+KPI_CODE_TO_DISPLAY_NAME = {
+    "avg_rt": "Average response time",
+    "pec50_rt": "50th percentile response time",
+    "pec90_rt": "90th percentile response time",
+    "pec95_rt": "95th percentile response time",
+    "pec99_rt": "99th percentile response time",
+}
+
+
 def _kpi_code_to_display_name(kpi_code: str) -> str:
     """Map BlazeMeter anomaly KPI codes to short display names for the LLM."""
-    mapping = {
-        "avg_rt": "Average response time",
-        "pec50_rt": "50th percentile response time",
-        "pec90_rt": "90th percentile response time",
-        "pec95_rt": "95th percentile response time",
-        "pec99_rt": "99th percentile response time",
-    }
-    return mapping.get(kpi_code, kpi_code)
+    return KPI_CODE_TO_DISPLAY_NAME.get(kpi_code, kpi_code)
 
 
 def _get_anomalies_detection_context() -> str:

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -21,7 +21,9 @@ from models.execution import (
     SummaryReport, SummaryReportMetrics,
     RequestStatsReport, RequestStatMetrics,
     ErrorReport, LabelErrors, HttpError, AssertionError, FailedEmbeddedResource, FailedUrl,
-    AnomalyDetail, AnomalyDetectionReport,
+    AffectedLabel,
+    AnomalyDetail,
+    AnomalyDetectionReport,
 )
 from tools.utils import get_date_time_iso
 
@@ -502,6 +504,42 @@ def _kpi_code_to_display_name(kpi_code: str) -> str:
     return KPI_CODE_TO_DISPLAY_NAME.get(kpi_code, kpi_code)
 
 
+def _first_label_id_for_name(anomalies: dict, label_name: str) -> str:
+    for row in anomalies.values():
+        if isinstance(row, dict) and str(row.get("labelName", "")) == label_name:
+            return str(row.get("labelId", ""))
+    return ""
+
+
+def _collect_affected_labels(affected_names: List[str], anomalies_raw: Any) -> List[AffectedLabel]:
+    """Build distinct affected labels with label_id resolved from anomaly rows when possible."""
+    rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
+    out: List[AffectedLabel] = []
+    seen: set[str] = set()
+
+    def _add(label_id: str, label_name: str) -> None:
+        key = label_id if label_id else label_name
+        if not key or key in seen:
+            return
+        seen.add(key)
+        out.append(AffectedLabel(ref_id=len(out) + 1, label_id=label_id, label_name=label_name))
+
+    if affected_names:
+        for name in affected_names:
+            lid = _first_label_id_for_name(rows, name) if rows else ""
+            _add(lid, name)
+        return out
+
+    for row in rows.values():
+        if not isinstance(row, dict):
+            continue
+        lid = str(row.get("labelId", ""))
+        lname = str(row.get("labelName", ""))
+        _add(lid, lname)
+
+    return out
+
+
 def _get_anomalies_detection_context() -> str:
     """Context for interpreting anomaly stats and routing the LLM to skills."""
     return (
@@ -513,13 +551,13 @@ def _get_anomalies_detection_context() -> str:
         "anomaly statistics (e.g. free tier or anomaly detection not enabled). Do not invent counts.\n"
         "- anomaly_count: Total anomalies when statistics are available; 0 means none detected. "
         "Null only when statistics_unavailable (unknown to this tool).\n"
-        "- affected_labels: Distinct label (transaction) names that had at least one anomaly.\n"
-        "- anomalies: Each row is one anomaly: label_id, label_name, kpi_name, start_time/end_time (ISO 8601), "
+        "- affected_labels: Distinct labels with ref_id, label_id and label_name that had at least one anomaly.\n"
+        "- anomalies: Each row is one anomaly: ref_id, kpi_name, start_time/end_time (ISO 8601), "
         "max_spike_height (spike severity for that KPI in that window).\n"
         "- statistics_unavailable_reason: Human-readable explanation when details cannot be shown.\n\n"
         "INTERPRETATION:\n"
         "- Prefer Timeline report in BlazeMeter UI to see anomalies visually; correlate with errors and KPIs.\n"
-        "- Multiple rows per label_name are normal (one per KPI).\n"
+        "- Multiple rows per ref_id are normal (one per KPI).\n"
         "- When statistics_unavailable: state clearly that anomaly details are not available for this account/session; "
         "suggest checking workspace/plan or help on anomaly detection.\n\n"
         "SKILL ROUTING:\n"
@@ -584,7 +622,12 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
         affected = []
 
     anomalies_raw = payload.get("anomalies")
+    affected_names = [str(x) for x in affected]
+    affected_labels = _collect_affected_labels(affected_names, anomalies_raw)
+
     details: List[AnomalyDetail] = []
+    ref_lookup = {item.label_id: item.ref_id for item in affected_labels if item.label_id}
+    ref_lookup.update({item.label_name: item.ref_id for item in affected_labels if item.label_name})
 
     if isinstance(anomalies_raw, dict):
         for _key, row in anomalies_raw.items():
@@ -593,10 +636,12 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             kpi = row.get("kpi") or ""
             st = row.get("startTime")
             en = row.get("endTime")
+            lid = str(row.get("labelId", ""))
+            lname = str(row.get("labelName", ""))
+            ref_id = (ref_lookup.get(lid) or ref_lookup.get(lname)) or 0
             details.append(
                 AnomalyDetail(
-                    label_id=str(row.get("labelId", "")),
-                    label_name=str(row.get("labelName", "")),
+                    ref_id=ref_id,
                     kpi_name=_kpi_code_to_display_name(kpi),
                     start_time=get_date_time_iso(int(st)) if st is not None else None,
                     end_time=get_date_time_iso(int(en)) if en is not None else None,
@@ -620,7 +665,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             execution_url=_build_execution_url(execution_id),
             anomaly_detection_status=status,
             anomaly_count=count,
-            affected_labels=affected,
+            affected_labels=affected_labels,
             anomalies=details,
             statistics_unavailable_reason=None,
             context=_get_anomalies_detection_context(),

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -20,7 +20,8 @@ from models.execution import (
     TestExecution, TestExecutionDetailed, TestExecutionStatus, TestExecutionStatuses,
     SummaryReport, SummaryReportMetrics,
     RequestStatsReport, RequestStatMetrics,
-    ErrorReport, LabelErrors, HttpError, AssertionError, FailedEmbeddedResource, FailedUrl
+    ErrorReport, LabelErrors, HttpError, AssertionError, FailedEmbeddedResource, FailedUrl,
+    AnomalyDetail, AnomalyDetectionReport,
 )
 from tools.utils import get_date_time_iso
 
@@ -485,6 +486,150 @@ def _get_error_report_context() -> str:
         "For deeper troubleshooting, consult the BlazeMeter skill blazemeter-performance-testing and related reporting resources.\n"
         "**CRITICAL**: Always follow the action schema exactly. If args are required, include args with exact names/types.\n"
     )
+
+
+def _kpi_code_to_display_name(kpi_code: str) -> str:
+    """Map BlazeMeter anomaly KPI codes to short display names for the LLM."""
+    mapping = {
+        "avg_rt": "Average response time",
+        "pec50_rt": "50th percentile response time",
+        "pec90_rt": "90th percentile response time",
+        "pec95_rt": "95th percentile response time",
+        "pec99_rt": "99th percentile response time",
+    }
+    return mapping.get(kpi_code, kpi_code)
+
+
+def _get_anomalies_detection_context() -> str:
+    """Context for interpreting anomaly stats and routing the LLM to skills."""
+    return (
+        "ANOMALY DETECTION RESPONSE — FIELD DEFINITIONS FOR THE LLM:\n"
+        "- anomaly_detection_status: "
+        "'no_anomalies' = API returned counts and anomaly_count is 0. "
+        "'anomalies_with_details' = API returned counts and a list of anomalies with KPIs and time windows. "
+        "'statistics_unavailable' = API returned no stats object (empty result); this token/account cannot retrieve "
+        "anomaly statistics (e.g. free tier or anomaly detection not enabled). Do not invent counts.\n"
+        "- anomaly_count: Total anomalies when statistics are available; 0 means none detected. "
+        "Null only when statistics_unavailable (unknown to this tool).\n"
+        "- affected_labels: Distinct label (transaction) names that had at least one anomaly.\n"
+        "- anomalies: Each row is one anomaly: label_name, kpi_code / kpi_display_name, time window (Unix + ISO), "
+        "max_spike_height (spike severity for that KPI in that window).\n"
+        "- statistics_unavailable_reason: Human-readable explanation when details cannot be shown.\n\n"
+        "INTERPRETATION:\n"
+        "- Prefer Timeline report in BlazeMeter UI to see anomalies visually; correlate with errors and KPIs.\n"
+        "- Multiple rows per label_name are normal (one per KPI).\n"
+        "- When statistics_unavailable: state clearly that anomaly details are not available for this account/session; "
+        "suggest checking workspace/plan or help on anomaly detection.\n\n"
+        "SKILL ROUTING:\n"
+        "- blazemeter-performance-testing: reporting.md (Timeline, anomaly testing), interpreting KPIs and next steps.\n"
+        "- blazemeter-administration: workspaces-projects.md (who can enable anomaly detection).\n\n"
+        "**CRITICAL**: Always follow the action schema exactly. If args are required, include args with exact names/types.\n"
+    )
+
+
+def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> List[AnomalyDetectionReport]:
+    """
+    Normalize /anomalies/stats API payloads into a single structured report.
+
+    The API may return:
+    - An empty list when anomaly statistics are not available for the account.
+    - A dict with anomalyCount, affectedLabel, and anomalies (object map or empty list when count is 0).
+    """
+    execution_id = params.get("execution_id") if params else None
+    execution_name = params.get("execution_name") if params else None
+    eid = execution_id or 0
+
+    if not raw:
+        return [
+            AnomalyDetectionReport(
+                execution_id=eid,
+                execution_name=execution_name,
+                execution_url=_build_execution_url(execution_id),
+                anomaly_detection_status="statistics_unavailable",
+                anomaly_count=None,
+                affected_labels=[],
+                anomalies=[],
+                statistics_unavailable_reason=(
+                    "BlazeMeter returned no anomaly statistics for this execution. "
+                    "This usually means anomaly detection is not available for your account or workspace "
+                    "(for example a limited plan), or the feature is disabled. Per-anomaly details cannot be shown."
+                ),
+                context=_get_anomalies_detection_context(),
+            )
+        ]
+
+    payload = raw[0]
+    if not isinstance(payload, dict):
+        return [
+            AnomalyDetectionReport(
+                execution_id=eid,
+                execution_name=execution_name,
+                execution_url=_build_execution_url(execution_id),
+                anomaly_detection_status="statistics_unavailable",
+                anomaly_count=None,
+                affected_labels=[],
+                anomalies=[],
+                statistics_unavailable_reason=(
+                    "Unexpected anomaly statistics payload; could not parse structured anomaly data."
+                ),
+                context=_get_anomalies_detection_context(),
+            )
+        ]
+
+    count = int(payload.get("anomalyCount", 0) or 0)
+    affected = payload.get("affectedLabel") or []
+    if not isinstance(affected, list):
+        affected = []
+
+    anomalies_raw = payload.get("anomalies")
+    details: List[AnomalyDetail] = []
+
+    if isinstance(anomalies_raw, dict):
+        for _key, row in anomalies_raw.items():
+            if not isinstance(row, dict):
+                continue
+            kpi = row.get("kpi") or ""
+            st = row.get("startTime")
+            en = row.get("endTime")
+            details.append(
+                AnomalyDetail(
+                    anomaly_id=str(row.get("anomalyId", "")),
+                    master_id=str(row.get("masterId", "")),
+                    label_id=str(row.get("labelId", "")),
+                    label_name=str(row.get("labelName", "")),
+                    kpi_code=kpi,
+                    kpi_display_name=_kpi_code_to_display_name(kpi),
+                    created_ms=int(row.get("created", 0) or 0),
+                    start_time_unix=int(st) if st is not None else 0,
+                    end_time_unix=int(en) if en is not None else 0,
+                    start_time_iso=get_date_time_iso(int(st)) if st is not None else None,
+                    end_time_iso=get_date_time_iso(int(en)) if en is not None else None,
+                    max_spike_height=float(row.get("maxSpikeHeight", 0) or 0),
+                )
+            )
+    elif isinstance(anomalies_raw, list) and not anomalies_raw:
+        pass
+
+    if count == 0 and not details:
+        status = "no_anomalies"
+    elif details or count > 0:
+        status = "anomalies_with_details"
+    else:
+        status = "no_anomalies"
+
+    return [
+        AnomalyDetectionReport(
+            execution_id=eid,
+            execution_name=execution_name,
+            execution_url=_build_execution_url(execution_id),
+            anomaly_detection_status=status,
+            anomaly_count=count,
+            affected_labels=affected,
+            anomalies=details,
+            statistics_unavailable_reason=None,
+            context=_get_anomalies_detection_context(),
+        )
+    ]
 
 
 def format_request_stats(request_stats_data: List[Any], params: Optional[dict] = None) -> List[RequestStatsReport]:

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -512,7 +512,7 @@ def _first_label_id_for_name(anomalies: dict, label_name: str) -> str:
     return ""
 
 
-def _collect_affected_labels(affected_names: List[str], anomalies_raw: Any) -> List[AffectedLabel]:
+def _collect_labels_affected(affected_names: List[str], anomalies_raw: Any) -> List[AffectedLabel]:
     """Build distinct affected labels with label_id resolved from anomaly rows when possible."""
     rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
     out: List[AffectedLabel] = []
@@ -575,7 +575,7 @@ def _get_anomalies_detection_context() -> str:
         "anomaly statistics (e.g. free tier or anomaly detection not enabled). Do not invent counts.\n"
         "- anomaly_count: Total anomalies when statistics are available; 0 means none detected. "
         "Null only when statistics_unavailable (unknown to this tool).\n"
-        "- affected_labels: Distinct labels with ref_id, label_id and label_name that had at least one anomaly.\n"
+        "- labels_affected: Distinct labels with ref_id, label_id and label_name that had at least one anomaly.\n"
         "- kpi_affected: Distinct KPIs with kpi_ref_id, kpi_id (API key) and kpi_name (human-readable).\n"
         "- anomalies: Each row is one anomaly: ref_id (label), kpi_ref_id (KPI), start_time/end_time (ISO 8601), "
         "max_spike_height (spike severity for that KPI in that window).\n"
@@ -612,7 +612,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
                 execution_url=_build_execution_url(execution_id),
                 anomaly_detection_status="statistics_unavailable",
                 anomaly_count=None,
-                affected_labels=[],
+                labels_affected=[],
                 kpi_affected=[],
                 anomalies=[],
                 statistics_unavailable_reason=(
@@ -633,7 +633,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
                 execution_url=_build_execution_url(execution_id),
                 anomaly_detection_status="statistics_unavailable",
                 anomaly_count=None,
-                affected_labels=[],
+                labels_affected=[],
                 kpi_affected=[],
                 anomalies=[],
                 statistics_unavailable_reason=(
@@ -650,12 +650,12 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
 
     anomalies_raw = payload.get("anomalies")
     affected_names = [str(x) for x in affected]
-    affected_labels = _collect_affected_labels(affected_names, anomalies_raw)
+    labels_affected = _collect_labels_affected(affected_names, anomalies_raw)
     kpi_affected, kpi_lookup = _collect_kpi_affected(anomalies_raw)
 
     details: List[AnomalyDetail] = []
-    ref_lookup = {item.label_id: item.ref_id for item in affected_labels if item.label_id}
-    ref_lookup.update({item.label_name: item.ref_id for item in affected_labels if item.label_name})
+    ref_lookup = {item.label_id: item.ref_id for item in labels_affected if item.label_id}
+    ref_lookup.update({item.label_name: item.ref_id for item in labels_affected if item.label_name})
 
     if isinstance(anomalies_raw, dict):
         for _key, row in anomalies_raw.items():
@@ -694,7 +694,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             execution_url=_build_execution_url(execution_id),
             anomaly_detection_status=status,
             anomaly_count=count,
-            affected_labels=affected_labels,
+            labels_affected=labels_affected,
             kpi_affected=kpi_affected,
             anomalies=details,
             statistics_unavailable_reason=None,

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -650,7 +650,7 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             )
         ]
 
-    count = int(payload.get("anomalyCount", 0) or 0)
+    count = int(payload.get("anomalyCount", 0))
     affected = payload.get("affectedLabel") or []
     if not isinstance(affected, list):
         affected = []

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -514,7 +514,7 @@ def _get_anomalies_detection_context() -> str:
         "- anomaly_count: Total anomalies when statistics are available; 0 means none detected. "
         "Null only when statistics_unavailable (unknown to this tool).\n"
         "- affected_labels: Distinct label (transaction) names that had at least one anomaly.\n"
-        "- anomalies: Each row is one anomaly: label_name, kpi_code / kpi_display_name, time window (Unix + ISO), "
+        "- anomalies: Each row is one anomaly: label_id, label_name, kpi_name, start_time/end_time (ISO 8601), "
         "max_spike_height (spike severity for that KPI in that window).\n"
         "- statistics_unavailable_reason: Human-readable explanation when details cannot be shown.\n\n"
         "INTERPRETATION:\n"
@@ -595,15 +595,11 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             en = row.get("endTime")
             details.append(
                 AnomalyDetail(
-                    anomaly_id=str(row.get("anomalyId", "")),
                     label_id=str(row.get("labelId", "")),
                     label_name=str(row.get("labelName", "")),
-                    kpi_display_name=_kpi_code_to_display_name(kpi),
-                    created_ms=int(row.get("created", 0) or 0),
-                    start_time_unix=int(st) if st is not None else 0,
-                    end_time_unix=int(en) if en is not None else 0,
-                    start_time_iso=get_date_time_iso(int(st)) if st is not None else None,
-                    end_time_iso=get_date_time_iso(int(en)) if en is not None else None,
+                    kpi_name=_kpi_code_to_display_name(kpi),
+                    start_time=get_date_time_iso(int(st)) if st is not None else None,
+                    end_time=get_date_time_iso(int(en)) if en is not None else None,
                     max_spike_height=float(row.get("maxSpikeHeight", 0) or 0),
                 )
             )

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -511,20 +511,31 @@ def _parse_anomalies_dict(
 ) -> tuple[List[AffectedLabel], List[AffectedKpi], List[AnomalyDetail]]:
     """
     Build labels_affected, kpi_affected, and per-row details from anomaly rows.
-    """
-    use_affected_list = bool(affected_names)
 
-    name_to_id: dict[str, str] = {}
+    This parser is intentionally label_id-first: dedupe, ref assignment, and detail linking
+    are all keyed by label_id. affected_names is accepted for interface compatibility but
+    does not drive ordering or filtering.
+    """
+    _ = affected_names
+
     kpi_affected: List[AffectedKpi] = []
     seen_kpi: set[str] = set()
     kpi_lookup: dict[str, int] = {}
 
     labels_affected: List[AffectedLabel] = []
-    seen_labels: set[str] = set()
     ref_lookup: dict[str, int] = {}
+    seen_lids: set[str] = set()
 
     details: List[AnomalyDetail] = []
-    pending: list[tuple[str, str, str, Any, Any, float]] = []
+
+    def anomaly_detail(lid: str, kpi: str, st: Any, en: Any, spike: float) -> AnomalyDetail:
+        return AnomalyDetail(
+            ref_id=ref_lookup.get(lid, 0),
+            kpi_ref_id=kpi_lookup.get(kpi) or 0,
+            start_time=get_date_time_iso(int(st)) if st is not None else None,
+            end_time=get_date_time_iso(int(en)) if en is not None else None,
+            max_spike_height=spike,
+        )
 
     for row in rows.values():
         if not isinstance(row, dict):
@@ -532,25 +543,12 @@ def _parse_anomalies_dict(
 
         lid = str(row.get("labelId", ""))
         lname = str(row.get("labelName", ""))
-        if lname and lname not in name_to_id:
-            name_to_id[lname] = lid
 
-        if not use_affected_list:
-            key = lid if lid else lname
-            if key and key not in seen_labels:
-                seen_labels.add(key)
-                ref = len(labels_affected) + 1
-                labels_affected.append(
-                    AffectedLabel(
-                        ref_id=ref, 
-                        label_id=lid, 
-                        label_name=lname
-                    )
-                )
-                if lid:
-                    ref_lookup[lid] = ref
-                if lname:
-                    ref_lookup[lname] = ref
+        if lid and lid not in seen_lids:
+            seen_lids.add(lid)
+            ref = len(labels_affected) + 1
+            labels_affected.append(AffectedLabel(ref_id=ref, label_id=lid, label_name=lname))
+            ref_lookup[lid] = ref
 
         kpi = str(row.get("kpi") or "")
         if kpi and kpi not in seen_kpi:
@@ -568,45 +566,7 @@ def _parse_anomalies_dict(
         st = row.get("startTime")
         en = row.get("endTime")
         spike = float(row.get("maxSpikeHeight", 0) or 0)
-
-        if use_affected_list:
-            pending.append((lid, lname, kpi, st, en, spike))
-        else:
-            details.append(
-                AnomalyDetail(
-                    ref_id=(ref_lookup.get(lid) or ref_lookup.get(lname)) or 0,
-                    kpi_ref_id=kpi_lookup.get(kpi) or 0,
-                    start_time=get_date_time_iso(int(st)) if st is not None else None,
-                    end_time=get_date_time_iso(int(en)) if en is not None else None,
-                    max_spike_height=spike,
-                )
-            )
-
-    if use_affected_list:
-        seen_labels = set()
-        for name in affected_names:
-            lid = name_to_id.get(name, "") or ""
-            key = lid if lid else name
-            if not key or key in seen_labels:
-                continue
-            seen_labels.add(key)
-            ref = len(labels_affected) + 1
-            labels_affected.append(AffectedLabel(ref_id=ref, label_id=lid, label_name=name))
-            if lid:
-                ref_lookup[lid] = ref
-            if name:
-                ref_lookup[name] = ref
-
-        details = [
-            AnomalyDetail(
-                ref_id=(ref_lookup.get(lid) or ref_lookup.get(lname)) or 0,
-                kpi_ref_id=kpi_lookup.get(kpi) or 0,
-                start_time=get_date_time_iso(int(st)) if st is not None else None,
-                end_time=get_date_time_iso(int(en)) if en is not None else None,
-                max_spike_height=spike,
-            )
-            for lid, lname, kpi, st, en, spike in pending
-        ]
+        details.append(anomaly_detail(lid, kpi, st, en, spike))
 
     return labels_affected, kpi_affected, details
 

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -505,63 +505,110 @@ def _kpi_code_to_display_name(kpi_code: str) -> str:
     return KPI_CODE_TO_DISPLAY_NAME.get(kpi_code, kpi_code)
 
 
-def _first_label_id_for_name(anomalies: dict, label_name: str) -> str:
-    for row in anomalies.values():
-        if isinstance(row, dict) and str(row.get("labelName", "")) == label_name:
-            return str(row.get("labelId", ""))
-    return ""
+def _parse_anomalies_dict(
+    rows: dict[str, Any],
+    affected_names: List[str],
+) -> tuple[List[AffectedLabel], List[AffectedKpi], List[AnomalyDetail]]:
+    """
+    Build labels_affected, kpi_affected, and per-row details from anomaly rows.
+    """
+    use_affected_list = bool(affected_names)
 
+    name_to_id: dict[str, str] = {}
+    kpi_affected: List[AffectedKpi] = []
+    seen_kpi: set[str] = set()
+    kpi_lookup: dict[str, int] = {}
 
-def _collect_labels_affected(affected_names: List[str], anomalies_raw: Any) -> List[AffectedLabel]:
-    """Build distinct affected labels with label_id resolved from anomaly rows when possible."""
-    rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
-    out: List[AffectedLabel] = []
-    seen: set[str] = set()
+    labels_affected: List[AffectedLabel] = []
+    seen_labels: set[str] = set()
+    ref_lookup: dict[str, int] = {}
 
-    def _add(label_id: str, label_name: str) -> None:
-        key = label_id if label_id else label_name
-        if not key or key in seen:
-            return
-        seen.add(key)
-        out.append(AffectedLabel(ref_id=len(out) + 1, label_id=label_id, label_name=label_name))
-
-    if affected_names:
-        for name in affected_names:
-            lid = _first_label_id_for_name(rows, name) if rows else ""
-            _add(lid, name)
-        return out
+    details: List[AnomalyDetail] = []
+    pending: list[tuple[str, str, str, Any, Any, float]] = []
 
     for row in rows.values():
         if not isinstance(row, dict):
             continue
+
         lid = str(row.get("labelId", ""))
         lname = str(row.get("labelName", ""))
-        _add(lid, lname)
+        if lname and lname not in name_to_id:
+            name_to_id[lname] = lid
 
-    return out
+        if not use_affected_list:
+            key = lid if lid else lname
+            if key and key not in seen_labels:
+                seen_labels.add(key)
+                ref = len(labels_affected) + 1
+                labels_affected.append(
+                    AffectedLabel(
+                        ref_id=ref, 
+                        label_id=lid, 
+                        label_name=lname
+                    )
+                )
+                if lid:
+                    ref_lookup[lid] = ref
+                if lname:
+                    ref_lookup[lname] = ref
 
-
-def _collect_kpi_affected(anomalies_raw: Any) -> tuple[List[AffectedKpi], dict[str, int]]:
-    """Distinct KPIs from anomaly rows with incremental kpi_ref_id; returns list and kpi_id -> kpi_ref_id lookup."""
-    rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
-    out: List[AffectedKpi] = []
-    seen: set[str] = set()
-    for row in rows.values():
-        if not isinstance(row, dict):
-            continue
-        kid = str(row.get("kpi") or "")
-        if not kid or kid in seen:
-            continue
-        seen.add(kid)
-        out.append(
-            AffectedKpi(
-                kpi_ref_id=len(out) + 1,
-                kpi_id=kid,
-                kpi_name=_kpi_code_to_display_name(kid),
+        kpi = str(row.get("kpi") or "")
+        if kpi and kpi not in seen_kpi:
+            seen_kpi.add(kpi)
+            kpi_ref = len(kpi_affected) + 1
+            kpi_affected.append(
+                AffectedKpi(
+                    kpi_ref_id=kpi_ref,
+                    kpi_id=kpi,
+                    kpi_name=_kpi_code_to_display_name(kpi),
+                )
             )
-        )
-    lookup = {item.kpi_id: item.kpi_ref_id for item in out}
-    return out, lookup
+            kpi_lookup[kpi] = kpi_ref
+
+        st = row.get("startTime")
+        en = row.get("endTime")
+        spike = float(row.get("maxSpikeHeight", 0) or 0)
+
+        if use_affected_list:
+            pending.append((lid, lname, kpi, st, en, spike))
+        else:
+            details.append(
+                AnomalyDetail(
+                    ref_id=(ref_lookup.get(lid) or ref_lookup.get(lname)) or 0,
+                    kpi_ref_id=kpi_lookup.get(kpi) or 0,
+                    start_time=get_date_time_iso(int(st)) if st is not None else None,
+                    end_time=get_date_time_iso(int(en)) if en is not None else None,
+                    max_spike_height=spike,
+                )
+            )
+
+    if use_affected_list:
+        seen_labels = set()
+        for name in affected_names:
+            lid = name_to_id.get(name, "") or ""
+            key = lid if lid else name
+            if not key or key in seen_labels:
+                continue
+            seen_labels.add(key)
+            ref = len(labels_affected) + 1
+            labels_affected.append(AffectedLabel(ref_id=ref, label_id=lid, label_name=name))
+            if lid:
+                ref_lookup[lid] = ref
+            if name:
+                ref_lookup[name] = ref
+
+        details = [
+            AnomalyDetail(
+                ref_id=(ref_lookup.get(lid) or ref_lookup.get(lname)) or 0,
+                kpi_ref_id=kpi_lookup.get(kpi) or 0,
+                start_time=get_date_time_iso(int(st)) if st is not None else None,
+                end_time=get_date_time_iso(int(en)) if en is not None else None,
+                max_spike_height=spike,
+            )
+            for lid, lname, kpi, st, en, spike in pending
+        ]
+
+    return labels_affected, kpi_affected, details
 
 
 def _get_anomalies_detection_context() -> str:
@@ -650,35 +697,8 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
 
     anomalies_raw = payload.get("anomalies")
     affected_names = [str(x) for x in affected]
-    labels_affected = _collect_labels_affected(affected_names, anomalies_raw)
-    kpi_affected, kpi_lookup = _collect_kpi_affected(anomalies_raw)
-
-    details: List[AnomalyDetail] = []
-    ref_lookup = {item.label_id: item.ref_id for item in labels_affected if item.label_id}
-    ref_lookup.update({item.label_name: item.ref_id for item in labels_affected if item.label_name})
-
-    if isinstance(anomalies_raw, dict):
-        for _key, row in anomalies_raw.items():
-            if not isinstance(row, dict):
-                continue
-            kpi = str(row.get("kpi") or "")
-            st = row.get("startTime")
-            en = row.get("endTime")
-            lid = str(row.get("labelId", ""))
-            lname = str(row.get("labelName", ""))
-            ref_id = (ref_lookup.get(lid) or ref_lookup.get(lname)) or 0
-            kpi_ref_id = kpi_lookup.get(kpi) or 0
-            details.append(
-                AnomalyDetail(
-                    ref_id=ref_id,
-                    kpi_ref_id=kpi_ref_id,
-                    start_time=get_date_time_iso(int(st)) if st is not None else None,
-                    end_time=get_date_time_iso(int(en)) if en is not None else None,
-                    max_spike_height=float(row.get("maxSpikeHeight", 0) or 0),
-                )
-            )
-    elif isinstance(anomalies_raw, list) and not anomalies_raw:
-        pass
+    rows = anomalies_raw if isinstance(anomalies_raw, dict) else {}
+    labels_affected, kpi_affected, details = _parse_anomalies_dict(rows, affected_names)
 
     if count == 0 and not details:
         status = "no_anomalies"

--- a/formatters/execution.py
+++ b/formatters/execution.py
@@ -596,10 +596,8 @@ def format_anomalies_stats(raw: List[Any], params: Optional[dict] = None) -> Lis
             details.append(
                 AnomalyDetail(
                     anomaly_id=str(row.get("anomalyId", "")),
-                    master_id=str(row.get("masterId", "")),
                     label_id=str(row.get("labelId", "")),
                     label_name=str(row.get("labelName", "")),
-                    kpi_code=kpi,
                     kpi_display_name=_kpi_code_to_display_name(kpi),
                     created_ms=int(row.get("created", 0) or 0),
                     start_time_unix=int(st) if st is not None else 0,

--- a/models/execution.py
+++ b/models/execution.py
@@ -191,7 +191,7 @@ class AffectedKpi(BaseModel):
 
 class AnomalyDetail(BaseModel):
     """One detected performance anomaly for a label and KPI (response-time metric)."""
-    ref_id: int = Field(description="Reference id to match the corresponding label in affected_labels")
+    ref_id: int = Field(description="Reference id to match the corresponding label in labels_affected")
     kpi_ref_id: int = Field(description="Reference id to match the corresponding KPI in kpi_affected")
     start_time: Optional[str] = Field(
         description="Start of the anomaly time window as ISO 8601 local datetime string",
@@ -227,7 +227,7 @@ class AnomalyDetectionReport(BaseModel):
         ),
         default=None,
     )
-    affected_labels: List[AffectedLabel] = Field(
+    labels_affected: List[AffectedLabel] = Field(
         description="Distinct labels that had at least one anomaly, each with ref_id, label_id, and label_name (empty if none or unavailable)",
         default_factory=list,
     )

--- a/models/execution.py
+++ b/models/execution.py
@@ -182,12 +182,17 @@ class AffectedLabel(BaseModel):
     label_name: str = Field(description="Human-readable label/transaction name")
 
 
+class AffectedKpi(BaseModel):
+    """One distinct KPI (response-time metric) that had at least one anomaly."""
+    kpi_ref_id: int = Field(description="Incremental KPI reference id starting at 1")
+    kpi_id: str = Field(description="Raw KPI key from the API (e.g. avg_rt, pec99_rt)")
+    kpi_name: str = Field(description="Human-readable KPI name for this kpi_id")
+
+
 class AnomalyDetail(BaseModel):
     """One detected performance anomaly for a label and KPI (response-time metric)."""
     ref_id: int = Field(description="Reference id to match the corresponding label in affected_labels")
-    kpi_name: str = Field(
-        description="Human-readable KPI name for this anomaly (e.g. average response time, 99th percentile response time)"
-    )
+    kpi_ref_id: int = Field(description="Reference id to match the corresponding KPI in kpi_affected")
     start_time: Optional[str] = Field(
         description="Start of the anomaly time window as ISO 8601 local datetime string",
         default=None,
@@ -226,8 +231,12 @@ class AnomalyDetectionReport(BaseModel):
         description="Distinct labels that had at least one anomaly, each with ref_id, label_id, and label_name (empty if none or unavailable)",
         default_factory=list,
     )
+    kpi_affected: List[AffectedKpi] = Field(
+        description="Distinct KPIs that had at least one anomaly, each with kpi_ref_id, kpi_id, and kpi_name (empty if none or unavailable)",
+        default_factory=list,
+    )
     anomalies: List[AnomalyDetail] = Field(
-        description="Per-anomaly rows when anomaly_detection_status is anomalies_with_details; otherwise empty",
+        description="Per-anomaly rows when anomaly_detection_status is anomalies_with_details; use ref_id and kpi_ref_id to correlate; otherwise empty",
         default_factory=list,
     )
     statistics_unavailable_reason: Optional[str] = Field(

--- a/models/execution.py
+++ b/models/execution.py
@@ -177,25 +177,17 @@ class ErrorReport(BaseModel):
 
 class AnomalyDetail(BaseModel):
     """One detected performance anomaly for a label and KPI (response-time metric)."""
-    anomaly_id: str = Field(description="Unique anomaly identifier from BlazeMeter")
     label_id: str = Field(description="Request label identifier the anomaly applies to")
     label_name: str = Field(description="Human-readable label/transaction name")
-    kpi_display_name: str = Field(
-        description="Short human-readable name for kpi_code (e.g. average response time, 95th percentile response time)"
+    kpi_name: str = Field(
+        description="Human-readable KPI name for this anomaly (e.g. average response time, 99th percentile response time)"
     )
-    created_ms: int = Field(description="When the anomaly record was created, as Unix time in milliseconds")
-    start_time_unix: int = Field(
-        description="Start of the anomalous time window in the test, Unix seconds (epoch)"
-    )
-    end_time_unix: int = Field(
-        description="End of the anomalous time window in the test, Unix seconds (epoch)"
-    )
-    start_time_iso: Optional[str] = Field(
-        description="start_time_unix as ISO 8601 local datetime string for readability",
+    start_time: Optional[str] = Field(
+        description="Start of the anomaly time window as ISO 8601 local datetime string",
         default=None,
     )
-    end_time_iso: Optional[str] = Field(
-        description="end_time_unix as ISO 8601 local datetime string for readability",
+    end_time: Optional[str] = Field(
+        description="End of the anomaly time window as ISO 8601 local datetime string",
         default=None,
     )
     max_spike_height: float = Field(

--- a/models/execution.py
+++ b/models/execution.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -173,3 +173,82 @@ class ErrorReport(BaseModel):
     label_errors: List[LabelErrors] = Field(description="List of errors grouped by label/endpoint")
     total_errors: int = Field(description="Total number of errors across all labels and error types")
     context: str = Field(description="Explanatory context about the error report format and metrics")
+
+
+class AnomalyDetail(BaseModel):
+    """One detected performance anomaly for a label and KPI (response-time metric)."""
+    anomaly_id: str = Field(description="Unique anomaly identifier from BlazeMeter")
+    master_id: str = Field(description="Execution (master) ID this anomaly belongs to")
+    label_id: str = Field(description="Request label identifier the anomaly applies to")
+    label_name: str = Field(description="Human-readable label/transaction name")
+    kpi_code: str = Field(
+        description=(
+            "Raw KPI key from the API (e.g. avg_rt, pec50_rt, pec90_rt, pec95_rt, pec99_rt). "
+            "Maps to response-time statistics used for anomaly detection."
+        )
+    )
+    kpi_display_name: str = Field(
+        description="Short human-readable name for kpi_code (e.g. average response time, 95th percentile response time)"
+    )
+    created_ms: int = Field(description="When the anomaly record was created, as Unix time in milliseconds")
+    start_time_unix: int = Field(
+        description="Start of the anomalous time window in the test, Unix seconds (epoch)"
+    )
+    end_time_unix: int = Field(
+        description="End of the anomalous time window in the test, Unix seconds (epoch)"
+    )
+    start_time_iso: Optional[str] = Field(
+        description="start_time_unix as ISO 8601 local datetime string for readability",
+        default=None,
+    )
+    end_time_iso: Optional[str] = Field(
+        description="end_time_unix as ISO 8601 local datetime string for readability",
+        default=None,
+    )
+    max_spike_height: float = Field(
+        description="Magnitude of the detected spike for this KPI in the anomaly window (API-specific unit, comparable within the same KPI)"
+    )
+
+
+class AnomalyDetectionReport(BaseModel):
+    """Structured anomaly detection response for a test execution (BlazeMeter /anomalies/stats)."""
+    execution_id: int = Field(description="The execution (master) ID this anomaly report belongs to")
+    execution_name: Optional[str] = Field(description="The execution display name when available", default=None)
+    execution_url: str = Field(description="URL to open this execution in the BlazeMeter UI")
+    anomaly_detection_status: Literal["no_anomalies", "anomalies_with_details", "statistics_unavailable"] = Field(
+        description=(
+            "Scenario for the LLM: "
+            "'no_anomalies' — API returned counts and anomalyCount is 0; no performance anomalies detected. "
+            "'anomalies_with_details' — API returned counts and per-anomaly rows; the account can view anomaly details. "
+            "'statistics_unavailable' — API returned an empty result list (feature not enabled for the account or insufficient "
+            "privilege); per-anomaly breakdown is not exposed to this token."
+        )
+    )
+    anomaly_count: Optional[int] = Field(
+        description=(
+            "Number of anomalies detected when statistics are available; 0 means none. "
+            "Null when statistics_unavailable (empty API result) so the true count is unknown to this integration."
+        ),
+        default=None,
+    )
+    affected_labels: List[str] = Field(
+        description="Distinct label names that had at least one anomaly (empty if none or unavailable)",
+        default_factory=list,
+    )
+    anomalies: List[AnomalyDetail] = Field(
+        description="Per-anomaly rows when anomaly_detection_status is anomalies_with_details; otherwise empty",
+        default_factory=list,
+    )
+    statistics_unavailable_reason: Optional[str] = Field(
+        description=(
+            "When anomaly_detection_status is statistics_unavailable, explains why (e.g. anomaly statistics not returned; "
+            "upgrade or account configuration). Null when statistics are available."
+        ),
+        default=None,
+    )
+    context: str = Field(
+        description=(
+            "Narrative and field-level guidance for the LLM: how to interpret anomaly_detection_status, when to suggest "
+            "BlazeMeter skills (e.g. Timeline report, anomaly help), and how to use anomaly_count vs anomalies."
+        )
+    )

--- a/models/execution.py
+++ b/models/execution.py
@@ -178,15 +178,8 @@ class ErrorReport(BaseModel):
 class AnomalyDetail(BaseModel):
     """One detected performance anomaly for a label and KPI (response-time metric)."""
     anomaly_id: str = Field(description="Unique anomaly identifier from BlazeMeter")
-    master_id: str = Field(description="Execution (master) ID this anomaly belongs to")
     label_id: str = Field(description="Request label identifier the anomaly applies to")
     label_name: str = Field(description="Human-readable label/transaction name")
-    kpi_code: str = Field(
-        description=(
-            "Raw KPI key from the API (e.g. avg_rt, pec50_rt, pec90_rt, pec95_rt, pec99_rt). "
-            "Maps to response-time statistics used for anomaly detection."
-        )
-    )
     kpi_display_name: str = Field(
         description="Short human-readable name for kpi_code (e.g. average response time, 95th percentile response time)"
     )

--- a/models/execution.py
+++ b/models/execution.py
@@ -175,10 +175,16 @@ class ErrorReport(BaseModel):
     context: str = Field(description="Explanatory context about the error report format and metrics")
 
 
+class AffectedLabel(BaseModel):
+    """One distinct label that had at least one anomaly (summary list)."""
+    ref_id: int = Field(description="Incremental label reference id starting at 1")
+    label_id: str = Field(description="BlazeMeter request label identifier (labelId)")
+    label_name: str = Field(description="Human-readable label/transaction name")
+
+
 class AnomalyDetail(BaseModel):
     """One detected performance anomaly for a label and KPI (response-time metric)."""
-    label_id: str = Field(description="Request label identifier the anomaly applies to")
-    label_name: str = Field(description="Human-readable label/transaction name")
+    ref_id: int = Field(description="Reference id to match the corresponding label in affected_labels")
     kpi_name: str = Field(
         description="Human-readable KPI name for this anomaly (e.g. average response time, 99th percentile response time)"
     )
@@ -216,8 +222,8 @@ class AnomalyDetectionReport(BaseModel):
         ),
         default=None,
     )
-    affected_labels: List[str] = Field(
-        description="Distinct label names that had at least one anomaly (empty if none or unavailable)",
+    affected_labels: List[AffectedLabel] = Field(
+        description="Distinct labels that had at least one anomaly, each with ref_id, label_id, and label_name (empty if none or unavailable)",
         default_factory=list,
     )
     anomalies: List[AnomalyDetail] = Field(

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -311,7 +311,7 @@ class TestFormatAnomaliesStats:
         assert report.affected_labels == ["Login Page"]
         assert len(report.anomalies) == 2
         a0 = report.anomalies[0]
-        assert a0.kpi_display_name == "Average response time"
+        assert a0.kpi_name == "Average response time"
         assert a0.max_spike_height == 5112.42
         a1 = report.anomalies[1]
-        assert a1.kpi_display_name == "99th percentile response time"
+        assert a1.kpi_name == "99th percentile response time"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -304,23 +304,27 @@ class TestFormatAnomaliesStats:
         ]
         result = format_anomalies_stats(api, {"execution_id": 81627918, "execution_name": "With anomalies"})
 
-        assert len(result) == 1
-        report = result[0]
-        assert report.anomaly_detection_status == "anomalies_with_details"
-        assert report.anomaly_count == 2
-        assert len(report.labels_affected) == 1
-        assert report.labels_affected[0].ref_id == 1
-        assert report.labels_affected[0].label_id == "lbl1"
-        assert report.labels_affected[0].label_name == "Login Page"
-        assert len(report.kpi_affected) == 2
-        k0, k1 = report.kpi_affected[0], report.kpi_affected[1]
-        assert k0.kpi_ref_id == 1 and k0.kpi_id == "avg_rt" and k0.kpi_name == "Average response time"
-        assert k1.kpi_ref_id == 2 and k1.kpi_id == "pec99_rt" and k1.kpi_name == "99th percentile response time"
-        assert len(report.anomalies) == 2
-        a0 = report.anomalies[0]
-        assert a0.ref_id == 1
-        assert a0.kpi_ref_id == 1
-        assert a0.max_spike_height == 5112.42
-        a1 = report.anomalies[1]
-        assert a1.ref_id == 1
-        assert a1.kpi_ref_id == 2
+        expected_report_subset = {
+            "anomaly_detection_status": "anomalies_with_details",
+            "anomaly_count": 2,
+            "labels_affected": [
+                {"ref_id": 1, "label_id": "lbl1", "label_name": "Login Page"},
+            ],
+            "kpi_affected": [
+                {"kpi_ref_id": 1, "kpi_id": "avg_rt", "kpi_name": "Average response time"},
+                {"kpi_ref_id": 2, "kpi_id": "pec99_rt", "kpi_name": "99th percentile response time"},
+            ],
+            "anomalies": [
+                {"ref_id": 1, "kpi_ref_id": 1, "max_spike_height": 5112.42},
+                {"ref_id": 1, "kpi_ref_id": 2, "max_spike_height": 5447.52},
+            ],
+        }
+        assert report.model_dump(
+            include={
+                "anomaly_detection_status": True,
+                "anomaly_count": True,
+                "labels_affected": {"__all__": {"ref_id", "label_id", "label_name"}},
+                "kpi_affected": {"__all__": {"kpi_ref_id", "kpi_id", "kpi_name"}},
+                "anomalies": {"__all__": {"ref_id", "kpi_ref_id", "max_spike_height"}},
+            }
+        ) == expected_report_subset

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -247,9 +247,18 @@ class TestFormatAnomaliesStats:
 
         assert len(result) == 1
         report = result[0]
-        assert report.anomaly_detection_status == "statistics_unavailable"
-        assert report.anomaly_count is None
-        assert report.anomalies == []
+        expected_report_subset = {
+            "anomaly_detection_status": "statistics_unavailable",
+            "anomaly_count": None,
+            "anomalies": [],
+        }
+        assert report.model_dump(
+            include={
+                "anomaly_detection_status": True,
+                "anomaly_count": True,
+                "anomalies": True,
+            }
+        ) == expected_report_subset
         assert report.statistics_unavailable_reason is not None
         assert "ANOMALY DETECTION RESPONSE" in report.context
 
@@ -265,11 +274,22 @@ class TestFormatAnomaliesStats:
 
         assert len(result) == 1
         report = result[0]
-        assert report.anomaly_detection_status == "no_anomalies"
-        assert report.anomaly_count == 0
-        assert report.labels_affected == []
-        assert report.anomalies == []
-        assert report.statistics_unavailable_reason is None
+        expected_report_subset = {
+            "anomaly_detection_status": "no_anomalies",
+            "anomaly_count": 0,
+            "labels_affected": [],
+            "anomalies": [],
+            "statistics_unavailable_reason": None,
+        }
+        assert report.model_dump(
+            include={
+                "anomaly_detection_status": True,
+                "anomaly_count": True,
+                "labels_affected": True,
+                "anomalies": True,
+                "statistics_unavailable_reason": True,
+            }
+        ) == expected_report_subset
 
     def test_anomalies_with_details(self):
         api = [
@@ -303,6 +323,7 @@ class TestFormatAnomaliesStats:
             }
         ]
         result = format_anomalies_stats(api, {"execution_id": 81627918, "execution_name": "With anomalies"})
+        report = result[0]
 
         expected_report_subset = {
             "anomaly_detection_status": "anomalies_with_details",

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -267,7 +267,7 @@ class TestFormatAnomaliesStats:
         report = result[0]
         assert report.anomaly_detection_status == "no_anomalies"
         assert report.anomaly_count == 0
-        assert report.affected_labels == []
+        assert report.labels_affected == []
         assert report.anomalies == []
         assert report.statistics_unavailable_reason is None
 
@@ -308,10 +308,10 @@ class TestFormatAnomaliesStats:
         report = result[0]
         assert report.anomaly_detection_status == "anomalies_with_details"
         assert report.anomaly_count == 2
-        assert len(report.affected_labels) == 1
-        assert report.affected_labels[0].ref_id == 1
-        assert report.affected_labels[0].label_id == "lbl1"
-        assert report.affected_labels[0].label_name == "Login Page"
+        assert len(report.labels_affected) == 1
+        assert report.labels_affected[0].ref_id == 1
+        assert report.labels_affected[0].label_id == "lbl1"
+        assert report.labels_affected[0].label_name == "Login Page"
         assert len(report.kpi_affected) == 2
         k0, k1 = report.kpi_affected[0], report.kpi_affected[1]
         assert k0.kpi_ref_id == 1 and k0.kpi_id == "avg_rt" and k0.kpi_name == "Average response time"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -15,7 +15,12 @@ limitations under the License.
 """
 import pytest
 
-from formatters.execution import format_request_stats, format_summary_report, format_error_report
+from formatters.execution import (
+    format_request_stats,
+    format_summary_report,
+    format_error_report,
+    format_anomalies_stats,
+)
 
 
 class TestFormatRequestStats:
@@ -233,3 +238,82 @@ class TestFormatErrorReport:
         # Totals
         assert label.total_errors_for_label == 3 + 2 + 1 + 4
         assert report.total_errors == 3 + 2 + 1 + 4
+
+
+class TestFormatAnomaliesStats:
+
+    def test_statistics_unavailable_empty_api_result(self):
+        result = format_anomalies_stats([], {"execution_id": 123, "execution_name": "Test"})
+
+        assert len(result) == 1
+        report = result[0]
+        assert report.anomaly_detection_status == "statistics_unavailable"
+        assert report.anomaly_count is None
+        assert report.anomalies == []
+        assert report.statistics_unavailable_reason is not None
+        assert "ANOMALY DETECTION RESPONSE" in report.context
+
+    def test_no_anomalies(self):
+        api = [
+            {
+                "anomalyCount": 0,
+                "affectedLabel": [],
+                "anomalies": [],
+            }
+        ]
+        result = format_anomalies_stats(api, {"execution_id": 456, "execution_name": "No anomalies run"})
+
+        assert len(result) == 1
+        report = result[0]
+        assert report.anomaly_detection_status == "no_anomalies"
+        assert report.anomaly_count == 0
+        assert report.affected_labels == []
+        assert report.anomalies == []
+        assert report.statistics_unavailable_reason is None
+
+    def test_anomalies_with_details(self):
+        api = [
+            {
+                "anomalyCount": 2,
+                "affectedLabel": ["Login Page"],
+                "anomalies": {
+                    "id1": {
+                        "anomalyId": "id1",
+                        "masterId": "81627918",
+                        "labelId": "lbl1",
+                        "created": 1774026305007,
+                        "kpi": "avg_rt",
+                        "startTime": 1774026170,
+                        "endTime": 1774026324,
+                        "maxSpikeHeight": 5112.42,
+                        "labelName": "Login Page",
+                    },
+                    "id2": {
+                        "anomalyId": "id2",
+                        "masterId": "81627918",
+                        "labelId": "lbl1",
+                        "created": 1774026305007,
+                        "kpi": "pec99_rt",
+                        "startTime": 1774026170,
+                        "endTime": 1774026322,
+                        "maxSpikeHeight": 5447.52,
+                        "labelName": "Login Page",
+                    },
+                },
+            }
+        ]
+        result = format_anomalies_stats(api, {"execution_id": 81627918, "execution_name": "With anomalies"})
+
+        assert len(result) == 1
+        report = result[0]
+        assert report.anomaly_detection_status == "anomalies_with_details"
+        assert report.anomaly_count == 2
+        assert report.affected_labels == ["Login Page"]
+        assert len(report.anomalies) == 2
+        a0 = report.anomalies[0]
+        assert a0.kpi_code == "avg_rt"
+        assert a0.kpi_display_name == "Average response time"
+        assert a0.max_spike_height == 5112.42
+        a1 = report.anomalies[1]
+        assert a1.kpi_code == "pec99_rt"
+        assert a1.kpi_display_name == "99th percentile response time"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -312,11 +312,15 @@ class TestFormatAnomaliesStats:
         assert report.affected_labels[0].ref_id == 1
         assert report.affected_labels[0].label_id == "lbl1"
         assert report.affected_labels[0].label_name == "Login Page"
+        assert len(report.kpi_affected) == 2
+        k0, k1 = report.kpi_affected[0], report.kpi_affected[1]
+        assert k0.kpi_ref_id == 1 and k0.kpi_id == "avg_rt" and k0.kpi_name == "Average response time"
+        assert k1.kpi_ref_id == 2 and k1.kpi_id == "pec99_rt" and k1.kpi_name == "99th percentile response time"
         assert len(report.anomalies) == 2
         a0 = report.anomalies[0]
         assert a0.ref_id == 1
-        assert a0.kpi_name == "Average response time"
+        assert a0.kpi_ref_id == 1
         assert a0.max_spike_height == 5112.42
         a1 = report.anomalies[1]
         assert a1.ref_id == 1
-        assert a1.kpi_name == "99th percentile response time"
+        assert a1.kpi_ref_id == 2

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -311,9 +311,7 @@ class TestFormatAnomaliesStats:
         assert report.affected_labels == ["Login Page"]
         assert len(report.anomalies) == 2
         a0 = report.anomalies[0]
-        assert a0.kpi_code == "avg_rt"
         assert a0.kpi_display_name == "Average response time"
         assert a0.max_spike_height == 5112.42
         a1 = report.anomalies[1]
-        assert a1.kpi_code == "pec99_rt"
         assert a1.kpi_display_name == "99th percentile response time"

--- a/tests/test_execution.py
+++ b/tests/test_execution.py
@@ -308,10 +308,15 @@ class TestFormatAnomaliesStats:
         report = result[0]
         assert report.anomaly_detection_status == "anomalies_with_details"
         assert report.anomaly_count == 2
-        assert report.affected_labels == ["Login Page"]
+        assert len(report.affected_labels) == 1
+        assert report.affected_labels[0].ref_id == 1
+        assert report.affected_labels[0].label_id == "lbl1"
+        assert report.affected_labels[0].label_name == "Login Page"
         assert len(report.anomalies) == 2
         a0 = report.anomalies[0]
+        assert a0.ref_id == 1
         assert a0.kpi_name == "Average response time"
         assert a0.max_spike_height == 5112.42
         a1 = report.anomalies[1]
+        assert a1.ref_id == 1
         assert a1.kpi_name == "99th percentile response time"

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -401,7 +401,9 @@ Actions:
 - read_all_reports: get all reports (summary, error, and request statistics) for a given execution ID.
     args(dict): Dictionary with the following required parameters:
         execution_id (int): The execution ID to get all reports for.
-- read_anomalies_stats: get anomaly statistics for a test execution (count, affected labels, per-anomaly KPI/time/spike details).
+- read_anomalies_stats: get anomaly detection results for a test execution. Response includes anomaly_detection_status
+    (no_anomalies | anomalies_with_details | statistics_unavailable), counts, affected labels, per-anomaly KPI/time windows,
+    and LLM context. When statistics_unavailable, details are not exposed for this account.
     args(dict): Dictionary with the following required parameters:
         execution_id (int): The execution (master) ID to get anomaly stats for.
 - ai_analysis: Trigger AI analysis for an execution and get dynamic responses based on polling results.

--- a/tools/report_manager.py
+++ b/tools/report_manager.py
@@ -19,7 +19,12 @@ from mcp.server.fastmcp import Context
 
 from config.blazemeter import EXECUTIONS_ENDPOINT
 from config.token import BzmToken
-from formatters.execution import format_summary_report, format_request_stats, format_error_report
+from formatters.execution import (
+    format_summary_report,
+    format_request_stats,
+    format_error_report,
+    format_anomalies_stats,
+)
 from models.manager import Manager
 from models.result import BaseResult
 from tools import bridge
@@ -128,7 +133,9 @@ class ReportManager(Manager):
     async def read_anomalies_stats(self, master_id: int):
         """
         Get anomaly statistics for a given master_id (test execution).
-        Returns anomaly count, affected labels, and per-anomaly details (KPI, time range, max spike).
+
+        Returns a structured report: no anomalies, full per-anomaly details when permitted, or
+        statistics_unavailable when the API returns no stats (e.g. account without anomaly access).
         """
         execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
         if execution_result.error:
@@ -139,8 +146,15 @@ class ReportManager(Manager):
                 error=EXECUTION_ARCHIVED_MSG,
             )
 
+        execution_name = self._extract_execution_name(execution_result)
+
         return await api_request(
             self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/anomalies/stats",
+            result_formatter=format_anomalies_stats,
+            result_formatter_params={
+                "execution_id": master_id,
+                "execution_name": execution_name,
+            },
         )


### PR DESCRIPTION
This change introduces a new anomaly detection response model and formatter to support the read_anomalies_stats tool with dynamic, account-aware behavior.

The /anomalies/stats payload is now normalized into a structured AnomalyDetectionReport that the LLM can reliably interpret. The formatter handles three scenarios: when a test has no anomalies, when anomalies exist and the user has privileges (returning detailed per-anomaly information such as label, KPI, time window, and spike magnitude), and when anomalies exist but the integration cannot access anomaly statistics (returning statistics_unavailable with an explicit explanation and without inventing counts/details).

To satisfy the tool’s LLM integration requirements, the response includes a context field that clearly defines every response parameter and provides guidance for subsequent actions (for example, recommending the BlazeMeter Timeline/anomaly-focused skills when details are available, and instructing the model how to communicate limitations when statistics are unavailable).