### PR TITLE
Failure Criteria

### DIFF
--- a/formatters/failure_criteria_labels.py
+++ b/formatters/failure_criteria_labels.py
@@ -1,0 +1,210 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional
+
+from models.failure_criteria import FailureCriteriaConfig, FailureCriterionRule
+
+KPI_FIELD_PRODUCT_LABEL_EN: Dict[str, str] = {
+    "responseTime.avg": "Avg. Response Time",
+    "responseTime.min": "Min response time",
+    "responseTime.max": "Max response time",
+    "responseTime.std": "Response time standard deviation",
+    "responseTime.percentile.0": "Percentile 0",
+    "responseTime.percentile.50": "Median / 50th percentile",
+    "responseTime.percentile.90": "90th percentile (P90)",
+    "responseTime.percentile.95": "95th percentile (P95)",
+    "responseTime.percentile.99": "99th percentile (P99)",
+    "latency.avg": "Average latency",
+    "connectTime.avg": "Average connect time",
+    "size.count": "Size count",
+    "size.avg": "Average size",
+    "size.rate": "Size rate",
+    "hits.count": "Hits count",
+    "hits.avg": "Average hits",
+    "hits.rate": "Avg. Hits/s",
+    "duration.count": "Duration count",
+    "errors.count": "Error count",
+    "errors.percent": "Error Percentage",
+    "errors.rate": "Error rate",
+}
+
+CONDITION_OP_PRODUCT_LABEL_EN: Dict[Optional[str], str] = {
+    None: "No condition selected",
+    "lt": "Less than",
+    "gt": "Greater than",
+    "eq": "Equal to",
+    "ne": "Not equal to",
+    "lte": "Less than or equal to",
+    "gte": "Greater than or equal to",
+}
+
+FAILURE_CRITERIA_GENERAL_FIELDS: List[Dict[str, str]] = [
+    {"key": "enabled", "label": "Failure Criteria section on or off for the test"},
+    {"key": "ignore_rampup", "label": "Ignore failure criteria during ramp-up (advanced configuration)"},
+    {"key": "sliding_window_for_all", "label": "Whether every rule uses 1-min slide window"},
+    {"key": "from_taurus", "label": "Failure criteria imported from Taurus script"},
+    {"key": "criteria_overridden_in_interface", "label": "Failure criteria overridden in product vs script"},
+]
+
+FAILURE_CRITERIA_TOP_LEVEL_TOOL_ARGS: List[Dict[str, Any]] = [
+    {
+        "key": "test_id",
+        "required": True,
+        "label": "BlazeMeter test id",
+    },
+    {"key": "enabled", "required": True, "label": "Turn Failure Criteria on or off for this test"},
+    {
+        "key": "rules",
+        "required": True,
+        "label": "Full list of criterion rows; replaces all existing rows for the test",
+    },
+    {
+        "key": "ignore_rampup",
+        "required": False,
+        "label": "Container-level ignore during ramp-up",
+    },
+    {
+        "key": "sliding_window_for_all",
+        "required": False,
+        "label": "If set, applies the same sliding_window boolean to every rule after parse",
+    },
+    {
+        "key": "from_taurus",
+        "required": False,
+        "label": "Threshold block fromTaurus",
+    },
+    {
+        "key": "criteria_overridden_in_interface",
+        "required": False,
+        "label": "Threshold block override flag",
+    },
+]
+
+FAILURE_CRITERIA_RULE_FIELDS: List[Dict[str, str]] = [
+    {"key": "kpi", "label": "Metric id"},
+    {"key": "label", "label": "Scope label for the metric (default ALL)"},
+    {"key": "condition", "label": "Operator code"},
+    {"key": "value", "label": "Threshold as string"},
+    {"key": "offset_percent", "label": "Baseline percentage offset string"},
+    {"key": "stop_test_on_violation", "label": "Stop the test when this criterion is violated"},
+    {"key": "sliding_window", "label": "1-min slide window eval for this row"},
+    {"key": "ignore_rampup", "label": "Per-row ignore ramp-up"},
+    {"key": "is_empty", "label": "Incomplete row"},
+]
+
+
+def _general_labels_dict() -> Dict[str, str]:
+    return {row["key"]: row["label"] for row in FAILURE_CRITERIA_GENERAL_FIELDS}
+
+
+def _rule_field_labels_dict() -> Dict[str, str]:
+    return {row["key"]: row["label"] for row in FAILURE_CRITERIA_RULE_FIELDS}
+
+
+def _condition_dict_key(op: Optional[str]) -> str:
+    """JSON-friendly key for condition_labels (null op maps to empty string)."""
+    return "" if op is None else str(op)
+
+
+def _label_for_condition(op: Optional[str]) -> str:
+    if op in CONDITION_OP_PRODUCT_LABEL_EN:
+        return CONDITION_OP_PRODUCT_LABEL_EN[op]
+    return op if op else CONDITION_OP_PRODUCT_LABEL_EN[None]
+
+
+def _collect_kpi_and_condition_labels(
+        rules: List[FailureCriterionRule],
+) -> tuple[Dict[str, str], Dict[str, str]]:
+    kpi_labels: Dict[str, str] = {}
+    condition_labels: Dict[str, str] = {}
+    for r in rules:
+        kid = r.kpi
+        if kid and kid not in kpi_labels:
+            kpi_labels[kid] = KPI_FIELD_PRODUCT_LABEL_EN.get(kid, kid)
+        ck = _condition_dict_key(r.condition)
+        if ck not in condition_labels:
+            condition_labels[ck] = _label_for_condition(r.condition)
+    return kpi_labels, condition_labels
+
+
+def build_failure_criteria_meta(rules: List[FailureCriterionRule]) -> Dict[str, Any]:
+    """
+    Per-test meta: static field definitions, label maps keyed like response fields, dynamic kpi/condition maps.
+    """
+    kpi_labels, condition_labels = _collect_kpi_and_condition_labels(rules)
+    return {
+        "general": copy.deepcopy(FAILURE_CRITERIA_GENERAL_FIELDS),
+        "general_labels": _general_labels_dict(),
+        "rule_fields": copy.deepcopy(FAILURE_CRITERIA_RULE_FIELDS),
+        "rule_field_labels": _rule_field_labels_dict(),
+        "kpi_labels": kpi_labels,
+        "condition_labels": condition_labels,
+    }
+
+
+def _format_rule_for_tool(rule: FailureCriterionRule) -> Dict[str, Any]:
+    """One rule: same keys as configure_failure_criteria rules[]."""
+    row: Dict[str, Any] = {
+        "kpi": rule.kpi,
+        "label": rule.label,
+        "condition": rule.condition,
+        "value": rule.value,
+        "offset_percent": rule.offset_percent,
+        "stop_test_on_violation": rule.stop_test_on_violation,
+        "sliding_window": rule.sliding_window,
+        "is_empty": rule.is_empty,
+    }
+    if rule.ignore_rampup is not None:
+        row["ignore_rampup"] = rule.ignore_rampup
+    return row
+
+
+def format_failure_criteria_for_tool(fc: FailureCriteriaConfig) -> Dict[str, Any]:
+    """failure_criteria on Test: same field names as configure_failure_criteria (plus meta)."""
+    out: Dict[str, Any] = {
+        "enabled": fc.enabled,
+        "ignore_rampup": fc.ignore_rampup,
+        "sliding_window_for_all": fc.sliding_window_for_all,
+        "meta": build_failure_criteria_meta(fc.rules),
+        "rules": [_format_rule_for_tool(r) for r in fc.rules],
+    }
+    if fc.from_taurus is not None:
+        out["from_taurus"] = fc.from_taurus
+    if fc.criteria_overridden_in_interface is not None:
+        out["criteria_overridden_in_interface"] = fc.criteria_overridden_in_interface
+    return out
+
+
+def failure_criteria_meta_payload() -> Dict[str, Any]:
+    """Catalog: parameters, field labels, KPI and condition value lists."""
+    kpis = [{"kpi": kid, "label": lbl} for kid, lbl in sorted(KPI_FIELD_PRODUCT_LABEL_EN.items())]
+    cond_items = list(CONDITION_OP_PRODUCT_LABEL_EN.items())
+    cond_items.sort(key=lambda x: ("\x00" if x[0] is None else str(x[0]),))
+    conditions = [{"op": op, "label": lbl} for op, lbl in cond_items]
+    return {
+        "layers": "Reading a test and configuring failure criteria use the same field names in tool data.",
+        "top_level_tool_args": copy.deepcopy(FAILURE_CRITERIA_TOP_LEVEL_TOOL_ARGS),
+        "rule_fields": copy.deepcopy(FAILURE_CRITERIA_RULE_FIELDS),
+        "general": copy.deepcopy(FAILURE_CRITERIA_GENERAL_FIELDS),
+        "general_labels": _general_labels_dict(),
+        "rule_field_labels": _rule_field_labels_dict(),
+        "kpis": kpis,
+        "conditions": conditions,
+    }

--- a/formatters/test.py
+++ b/formatters/test.py
@@ -13,15 +13,70 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Any, Optional
+from typing import Any, Dict, List, Optional
 
+from formatters.failure_criteria_labels import format_failure_criteria_for_tool
+from models.failure_criteria import FailureCriteriaConfig, FailureCriterionRule
 from models.test import Test
 from tools.utils import get_date_time_iso
+
+
+def _get_failure_criterion_rule_from_api_item(item: Dict[str, Any]) -> FailureCriterionRule:
+    return FailureCriterionRule(
+        kpi=(item.get("field") or "")
+        if isinstance(item.get("field"), str)
+        else str(item.get("field") or ""),
+        label=item.get("label") if isinstance(item.get("label"), str) else "ALL",
+        condition=item.get("op"),
+        value=str(item.get("value", "")),
+        offset_percent=str(item.get("offsetPercentage", "0.0")),
+        stop_test_on_violation=bool(item.get("stopTestOnViolation", False)),
+        sliding_window=bool(item.get("slidingWindow", False)),
+        ignore_rampup=item.get("ignoreRampup") if isinstance(item.get("ignoreRampup"), bool) else None,
+        is_empty=bool(item.get("isEmpty", False)),
+    )
+
+
+def format_failure_criteria(configuration: Dict[str, Any]) -> FailureCriteriaConfig:
+    """Map BlazeMeter test configuration JSON to the failure_criteria domain model (read path)."""
+    if not isinstance(configuration, dict):
+        return FailureCriteriaConfig(enabled=False, rules=[])
+
+    enabled = bool(configuration.get("enableFailureCriteria", False))
+    plugins = configuration.get("plugins")
+    if not isinstance(plugins, dict):
+        return FailureCriteriaConfig(enabled=enabled, rules=[])
+
+    th = plugins.get("thresholds")
+    if not isinstance(th, dict):
+        return FailureCriteriaConfig(enabled=enabled, rules=[])
+
+    raw_rules = th.get("thresholds")
+    rules: List[FailureCriterionRule] = []
+    if isinstance(raw_rules, list):
+        for item in raw_rules:
+            if isinstance(item, dict):
+                rules.append(_get_failure_criterion_rule_from_api_item(item))
+
+    def _optional_bool(key: str) -> Optional[bool]:
+        v = th.get(key)
+        return v if isinstance(v, bool) else None
+
+    return FailureCriteriaConfig(
+        enabled=enabled,
+        rules=rules,
+        ignore_rampup=_optional_bool("ignoreRampup"),
+        from_taurus=_optional_bool("fromTaurus"),
+        criteria_overridden_in_interface=_optional_bool("isOverriddenByUi"),
+    )
 
 
 def format_tests(tests: List[Any], params: Optional[dict] = None) -> List[Test]:
     formatted_tests = []
     for test in tests:
+        configuration = test.get("configuration", {})
+        if not isinstance(configuration, dict):
+            configuration = {}
         formatted_tests.append(
             Test(
                 test_id=test.get("id"),
@@ -30,8 +85,11 @@ def format_tests(tests: List[Any], params: Optional[dict] = None) -> List[Test]:
                 created=get_date_time_iso(test.get("created")),
                 updated=get_date_time_iso(test.get("updated")),
                 project_id=test.get("projectId"),
-                configuration=test.get("configuration", {}),
-                override_executions=test.get("overrideExecutions", [])
+                configuration=configuration,
+                override_executions=test.get("overrideExecutions", []),
+                failure_criteria=format_failure_criteria_for_tool(
+                    format_failure_criteria(configuration)
+                ),
             )
         )
     return formatted_tests

--- a/main.py
+++ b/main.py
@@ -126,7 +126,7 @@ A comprehensive integration tool that provides AI assistants with full programma
 ## User Confirmation Required
 
 - **ALWAYS ask for explicit user confirmation** before performing any action that creates, modifies, or alters anything in the user's BlazeMeter configurations, accounts, workspaces, projects or tests.
-- **Actions requiring confirmation**: Creating tests, configuring load/locations, uploading assets, starting executions, or any other write/modify operations.
+- **Actions requiring confirmation**: Creating tests, configuring load/locations/failure criteria, uploading assets, starting executions, or any other write/modify operations.
 - **How to request**: Clearly state what action you're about to perform and on which workspace/project. Wait for user approval before proceeding.
 
 ## Proactive Knowledge Consultation
@@ -150,6 +150,7 @@ A comprehensive integration tool that provides AI assistants with full programma
 - **Never modify without confirmation**: Always ask before creating, modifying, or altering anything in BlazeMeter.
 - **Always confirm context**: Always identify and confirm workspace/project before operations.
 - **Proactive Troubleshooting**: Use the skills for troubleshooting any detected issues.
+- **Failure criteria**: The same field names appear when you read a test and when you configure failure criteria (`failure_criteria` on the test); the server handles BlazeMeter’s REST format internally. Use `failure_criteria_meta` for field definitions and KPI/condition catalogs. When describing criteria to the user, use `meta.general_labels`, `meta.rule_field_labels`, `meta.kpi_labels`, and `meta.condition_labels`; use raw metric and operator ids only inside tool calls. Use `configure_failure_criteria` only after user confirmation; it replaces all rules unless you merge from a prior read.
     """
     mcp = FastMCP("blazemeter-mcp", instructions=instructions, log_level=cast(LOG_LEVELS, log_level))
     register_confirm_mode(confirm_mode)

--- a/models/failure_criteria.py
+++ b/models/failure_criteria.py
@@ -1,0 +1,233 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+# HTTP JSON uses BlazeMeter camelCase (enableFailureCriteria, stopTestOnViolation, …).
+# Domain models here match the field names used in tool read/configure responses and arguments.
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+
+class FailureCriterionRule(BaseModel):
+    """One failure criterion row (domain naming; API uses plugins.thresholds.thresholds[])."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    kpi: str = Field(description="API field name for the KPI, e.g. responseTime.avg, errors.rate")
+    label: str = Field(default="ALL", description="Label scope; default ALL")
+    condition: Optional[str] = Field(
+        default=None,
+        description="Comparison operator: lt, gt, eq, ne, lte, gte; None matches API null",
+    )
+    value: str = Field(default="", description="Threshold as string, same as API")
+    offset_percent: str = Field(default="0.0", description="Baseline offset percentage string")
+    stop_test_on_violation: bool = Field(
+        default=False,
+        description="Stop Test (API stopTestOnViolation); typically used with 1-min slide window",
+    )
+    sliding_window: bool = Field(
+        default=False,
+        description="1-min slide window eval for this rule (API slidingWindow)",
+    )
+    ignore_rampup: Optional[bool] = Field(
+        default=None,
+        description="Per-rule ignore ramp-up when API sends it; None omits key on write",
+    )
+    is_empty: bool = Field(
+        default=False,
+        description="Incomplete row flag from API (isEmpty)",
+    )
+
+
+class FailureCriteriaConfig(BaseModel):
+    """Failure criteria section (domain model)."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    enabled: bool = Field(
+        description="Section master switch (API configuration.enableFailureCriteria)",
+    )
+    rules: List[FailureCriterionRule] = Field(default_factory=list)
+    ignore_rampup: Optional[bool] = Field(
+        default=None,
+        description="Container-level ignore ramp-up; None preserves existing on merge",
+    )
+    from_taurus: Optional[bool] = Field(
+        default=None,
+        description="fromTaurus; None preserves existing on merge",
+    )
+    criteria_overridden_in_interface: Optional[bool] = Field(
+        default=None,
+        description="Threshold-block flag from the API; None preserves existing on merge",
+    )
+
+    @computed_field
+    @property
+    def sliding_window_for_all(self) -> bool:
+        """
+        True when at least one rule exists and every rule has sliding_window enabled
+        (same idea as bulk 'Enable 1-min slide window eval for all' in the product).
+        """
+        if not self.rules:
+            return False
+        return all(r.sliding_window for r in self.rules)
+
+
+def rule_to_api_dict(rule: FailureCriterionRule) -> Dict[str, Any]:
+    """Serialize one rule to API item shape (camelCase keys)."""
+    out: Dict[str, Any] = {
+        "field": rule.kpi,
+        "label": rule.label,
+        "op": rule.condition,
+        "value": rule.value,
+        "offsetPercentage": rule.offset_percent,
+        "isEmpty": rule.is_empty,
+        "stopTestOnViolation": rule.stop_test_on_violation,
+        "slidingWindow": rule.sliding_window,
+    }
+    if rule.ignore_rampup is not None:
+        out["ignoreRampup"] = rule.ignore_rampup
+    return out
+
+
+def merge_failure_criteria_into_configuration_dict(
+        existing_configuration: Dict[str, Any],
+        fc: FailureCriteriaConfig,
+) -> Dict[str, Any]:
+    """
+    Return a full configuration dict with failure criteria applied.
+    Preserves plugins.jmeter and other configuration keys; merges plugins.thresholds metadata.
+    """
+    out = copy.deepcopy(existing_configuration) if isinstance(existing_configuration, dict) else {}
+    if not isinstance(out, dict):
+        out = {}
+
+    plugins = out.setdefault("plugins", {})
+    if not isinstance(plugins, dict):
+        plugins = {}
+        out["plugins"] = plugins
+
+    jmeter = plugins.get("jmeter")
+    prev_th = plugins.get("thresholds")
+    prev_dict: Dict[str, Any] = dict(prev_th) if isinstance(prev_th, dict) else {}
+
+    new_th: Dict[str, Any] = {**prev_dict}
+    new_th["thresholds"] = [rule_to_api_dict(r) for r in fc.rules]
+
+    def _merge_meta(key: str, fc_val: Optional[bool], default: bool) -> None:
+        if fc_val is not None:
+            new_th[key] = fc_val
+        elif key in prev_dict:
+            new_th[key] = prev_dict[key]
+        else:
+            new_th[key] = default
+
+    _merge_meta("ignoreRampup", fc.ignore_rampup, False)
+    _merge_meta("fromTaurus", fc.from_taurus, False)
+    _merge_meta("isOverriddenByUi", fc.criteria_overridden_in_interface, True)
+
+    plugins["thresholds"] = new_th
+    if jmeter is not None:
+        plugins["jmeter"] = jmeter
+
+    out["enableFailureCriteria"] = fc.enabled
+    return out
+
+
+def _require_bool(value: Any, message: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(message)
+    return value
+
+
+def _optional_bool_arg(value: Any, arg_name: str) -> Optional[bool]:
+    if value is None:
+        return None
+    if not isinstance(value, bool):
+        raise ValueError(f"Invalid argument '{arg_name}'. Expected boolean or omit.")
+    return value
+
+
+def _parse_configure_rule(raw: Any, index: int) -> FailureCriterionRule:
+    if not isinstance(raw, dict):
+        raise ValueError(f"Invalid rules[{index}]: expected an object.")
+    kpi = raw.get("kpi")
+    if not isinstance(kpi, str) or not kpi.strip():
+        raise ValueError(f"Invalid rules[{index}].kpi: required non-empty string.")
+    cond = raw.get("condition")
+    if cond is not None and not isinstance(cond, str):
+        raise ValueError(f"Invalid rules[{index}].condition: expected string or null.")
+    ir = raw.get("ignore_rampup")
+    if ir is not None and not isinstance(ir, bool):
+        raise ValueError(f"Invalid rules[{index}].ignore_rampup: expected boolean or omit.")
+    label = raw["label"] if isinstance(raw.get("label"), str) else "ALL"
+    return FailureCriterionRule(
+        kpi=kpi.strip(),
+        label=label,
+        condition=cond,
+        value=str(raw.get("value", "")),
+        offset_percent=str(raw.get("offset_percent", "0.0")),
+        stop_test_on_violation=bool(raw.get("stop_test_on_violation", False)),
+        sliding_window=bool(raw.get("sliding_window", False)),
+        ignore_rampup=ir,
+        is_empty=bool(raw.get("is_empty", False)),
+    )
+
+
+def _rules_from_configure_args(rules_raw: Any) -> List[FailureCriterionRule]:
+    if rules_raw is None:
+        raise ValueError(
+            "Missing required argument 'rules'. Expected a list (use empty list to clear rules)."
+        )
+    if not isinstance(rules_raw, list):
+        raise ValueError("Invalid argument 'rules'. Expected a list.")
+    return [_parse_configure_rule(raw, i) for i, raw in enumerate(rules_raw)]
+
+
+def _apply_sliding_window_for_all(
+        rules: List[FailureCriterionRule], value: Optional[bool]
+) -> List[FailureCriterionRule]:
+    if value is None:
+        return rules
+    return [r.model_copy(update={"sliding_window": value}) for r in rules]
+
+
+def failure_criteria_from_configure_args(args: Dict[str, Any]) -> FailureCriteriaConfig:
+    """
+    Validate blazemeter_tests configure_failure_criteria args and build FailureCriteriaConfig.
+    Raises ValueError with a message suitable for BaseResult.error.
+    """
+    enabled = _require_bool(
+        args.get("enabled"),
+        "Missing or invalid required argument 'enabled'. Expected boolean.",
+    )
+    rules = _rules_from_configure_args(args.get("rules"))
+    sw_all = _optional_bool_arg(args.get("sliding_window_for_all"), "sliding_window_for_all")
+    rules = _apply_sliding_window_for_all(rules, sw_all)
+
+    return FailureCriteriaConfig(
+        enabled=enabled,
+        rules=rules,
+        ignore_rampup=_optional_bool_arg(args.get("ignore_rampup"), "ignore_rampup"),
+        from_taurus=_optional_bool_arg(args.get("from_taurus"), "from_taurus"),
+        criteria_overridden_in_interface=_optional_bool_arg(
+            args.get("criteria_overridden_in_interface"),
+            "criteria_overridden_in_interface",
+        ),
+    )

--- a/models/test.py
+++ b/models/test.py
@@ -28,3 +28,11 @@ class Test(BaseModel):
     project_id: int = Field(description="The Project ID")
     configuration: Dict[str, Any] = Field(description="Contains all the advanced BlazeMeter related configurations")
     override_executions: List[Optional[Any]] = Field(description="The test settings used when running the test in BlazeMeter")
+    failure_criteria: Dict[str, Any] = Field(
+        description=(
+            "Failure criteria: field names match configure_failure_criteria (enabled, rules, …) "
+            "plus meta (general_labels, rule_field_labels, kpi_labels, condition_labels for display). "
+            "BlazeMeter REST property names are used only inside the server. For user-facing text, "
+            "use meta labels; keep raw kpi/op ids for tool parameters only."
+        ),
+    )

--- a/tests/test_failure_criteria.py
+++ b/tests/test_failure_criteria.py
@@ -1,0 +1,287 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import asyncio
+
+import pytest
+
+from config.blazemeter import TOOLS_PREFIX
+from formatters.failure_criteria_labels import (
+    FAILURE_CRITERIA_GENERAL_FIELDS,
+    failure_criteria_meta_payload,
+    format_failure_criteria_for_tool,
+)
+from formatters.test import format_failure_criteria, format_tests
+from models.failure_criteria import (
+    FailureCriteriaConfig,
+    FailureCriterionRule,
+    failure_criteria_from_configure_args,
+    merge_failure_criteria_into_configuration_dict,
+    rule_to_api_dict,
+)
+from tools.test_manager import register as register_tests_tool
+
+
+class TestFormatFailureCriteria:
+    def test_empty_configuration(self):
+        fc = format_failure_criteria({})
+        assert fc.enabled is False
+        assert fc.rules == []
+        assert fc.sliding_window_for_all is False
+
+    def test_parses_rules_and_enabled(self):
+        cfg = {
+            "enableFailureCriteria": True,
+            "plugins": {
+                "thresholds": {
+                    "thresholds": [
+                        {
+                            "field": "errors.rate",
+                            "label": "ALL",
+                            "op": "gte",
+                            "value": "1",
+                            "offsetPercentage": "0.0",
+                            "isEmpty": False,
+                            "stopTestOnViolation": False,
+                            "ignoreRampup": False,
+                            "slidingWindow": True,
+                        }
+                    ],
+                    "ignoreRampup": True,
+                    "fromTaurus": False,
+                    "isOverriddenByUi": True,
+                },
+                "jmeter": {"version": "stable"},
+            },
+        }
+        fc = format_failure_criteria(cfg)
+        assert fc.enabled is True
+        assert len(fc.rules) == 1
+        assert fc.rules[0].kpi == "errors.rate"
+        assert fc.rules[0].sliding_window is True
+        assert fc.ignore_rampup is True
+        assert fc.sliding_window_for_all is True
+
+    def test_sliding_window_for_all_false_when_one_rule_off(self):
+        cfg = {
+            "enableFailureCriteria": True,
+            "plugins": {
+                "thresholds": {
+                    "thresholds": [
+                        {"field": "a", "slidingWindow": True},
+                        {"field": "b", "slidingWindow": False},
+                    ]
+                }
+            },
+        }
+        fc = format_failure_criteria(cfg)
+        assert fc.sliding_window_for_all is False
+
+
+class TestFormatFailureCriteriaForTool:
+    def test_mcp_keys_match_tool_args(self):
+        fc = FailureCriteriaConfig(
+            enabled=True,
+            ignore_rampup=True,
+            rules=[
+                FailureCriterionRule(
+                    kpi="errors.percent",
+                    label="ALL",
+                    condition="gte",
+                    value="5",
+                    offset_percent="0.0",
+                    stop_test_on_violation=True,
+                    sliding_window=True,
+                )
+            ],
+        )
+        out = format_failure_criteria_for_tool(fc)
+        assert out["enabled"] is True
+        assert out["ignore_rampup"] is True
+        assert out["sliding_window_for_all"] is True
+        assert out["meta"]["kpi_labels"]["errors.percent"] == "Error Percentage"
+        assert out["meta"]["condition_labels"]["gte"] == "Greater than or equal to"
+        row = out["rules"][0]
+        assert row["kpi"] == "errors.percent"
+        assert row["condition"] == "gte"
+        assert row["value"] == "5"
+        assert row["offset_percent"] == "0.0"
+        assert row["stop_test_on_violation"] is True
+        assert row["sliding_window"] is True
+
+    def test_meta_uses_empty_string_key_for_null_condition(self):
+        fc = FailureCriteriaConfig(
+            enabled=True,
+            rules=[FailureCriterionRule(kpi="errors.rate", condition=None, value="")],
+        )
+        out = format_failure_criteria_for_tool(fc)
+        assert out["meta"]["condition_labels"][""] == "No condition selected"
+        assert out["rules"][0]["condition"] is None
+
+    def test_meta_structure_when_no_rules(self):
+        out = format_failure_criteria_for_tool(FailureCriteriaConfig(enabled=False, rules=[]))
+        assert out["meta"]["kpi_labels"] == {}
+        assert out["meta"]["condition_labels"] == {}
+        assert len(out["meta"]["general"]) == len(FAILURE_CRITERIA_GENERAL_FIELDS)
+        assert out["meta"]["general"][0]["key"] == "enabled"
+        assert out["meta"]["general_labels"]["enabled"] == "Failure Criteria section on or off for the test"
+        assert "stop_test_on_violation" in out["meta"]["rule_field_labels"]
+
+    def test_format_tests_failure_criteria_shape(self):
+        tests = format_tests(
+            [
+                {
+                    "id": 1,
+                    "name": "t",
+                    "description": "",
+                    "projectId": 9,
+                    "configuration": {
+                        "enableFailureCriteria": True,
+                        "plugins": {
+                            "thresholds": {
+                                "thresholds": [
+                                    {
+                                        "field": "hits.rate",
+                                        "label": "ALL",
+                                        "op": "lt",
+                                        "value": "10",
+                                        "offsetPercentage": "0.0",
+                                        "isEmpty": False,
+                                        "stopTestOnViolation": False,
+                                        "slidingWindow": False,
+                                    }
+                                ],
+                                "ignoreRampup": False,
+                            }
+                        },
+                    },
+                    "overrideExecutions": [],
+                }
+            ]
+        )
+        fc = tests[0].failure_criteria
+        assert fc["enabled"] is True
+        assert fc["meta"]["kpi_labels"]["hits.rate"] == "Avg. Hits/s"
+        assert fc["meta"]["condition_labels"]["lt"] == "Less than"
+
+
+class TestSerializeAndMerge:
+    def test_rule_to_api_dict(self):
+        r = FailureCriterionRule(
+            kpi="responseTime.avg",
+            label="ALL",
+            condition="gt",
+            value="500",
+            offset_percent="0.0",
+            stop_test_on_violation=True,
+            sliding_window=True,
+            ignore_rampup=True,
+        )
+        d = rule_to_api_dict(r)
+        assert d["field"] == "responseTime.avg"
+        assert d["slidingWindow"] is True
+        assert d["stopTestOnViolation"] is True
+        assert d["ignoreRampup"] is True
+
+    def test_merge_preserves_jmeter(self):
+        existing = {
+            "type": "taurus",
+            "plugins": {
+                "jmeter": {"version": "stable", "consoleArgs": ""},
+                "thresholds": {
+                    "thresholds": [],
+                    "ignoreRampup": False,
+                    "fromTaurus": False,
+                    "isOverriddenByUi": False,
+                },
+            },
+        }
+        fc = FailureCriteriaConfig(
+            enabled=True,
+            rules=[
+                FailureCriterionRule(
+                    kpi="errors.rate",
+                    condition="gte",
+                    value="5",
+                    sliding_window=False,
+                )
+            ],
+        )
+        merged = merge_failure_criteria_into_configuration_dict(existing, fc)
+        assert merged["plugins"]["jmeter"]["version"] == "stable"
+        assert len(merged["plugins"]["thresholds"]["thresholds"]) == 1
+        assert merged["plugins"]["thresholds"]["thresholds"][0]["field"] == "errors.rate"
+        assert merged["enableFailureCriteria"] is True
+
+
+class TestFailureCriteriaFromConfigureArgs:
+    def test_sliding_window_for_all_overrides_each_rule(self):
+        fc = failure_criteria_from_configure_args(
+            {
+                "enabled": True,
+                "rules": [
+                    {"kpi": "a", "sliding_window": False},
+                    {"kpi": "b", "sliding_window": False},
+                ],
+                "sliding_window_for_all": True,
+            }
+        )
+        assert all(r.sliding_window for r in fc.rules)
+        assert fc.sliding_window_for_all is True
+
+    def test_requires_enabled_and_rules(self):
+        with pytest.raises(ValueError, match="enabled"):
+            failure_criteria_from_configure_args({"rules": []})
+        with pytest.raises(ValueError, match="rules"):
+            failure_criteria_from_configure_args({"enabled": True})
+
+
+class _FakeMcpForTests:
+    def __init__(self):
+        self.tools = {}
+
+    def tool(self, name, description):
+        def decorator(func):
+            self.tools[name] = func
+            return func
+
+        return decorator
+
+
+class TestFailureCriteriaMetaPayload:
+    def test_contains_catalog(self):
+        p = failure_criteria_meta_payload()
+        assert "layers" in p
+        assert "top_level_tool_args" in p and "rule_fields" in p
+        assert "general" in p and "kpis" in p and "conditions" in p
+        assert len(p["general"]) == len(FAILURE_CRITERIA_GENERAL_FIELDS)
+        assert any(x["key"] == "test_id" for x in p["top_level_tool_args"])
+        assert any(x["key"] == "kpi" for x in p["rule_fields"])
+        assert p["general_labels"]["ignore_rampup"]
+        assert "value" in p["rule_field_labels"]
+
+
+class TestFailureCriteriaMetaAction:
+    def test_tool_returns_catalog_without_api(self):
+        mcp = _FakeMcpForTests()
+        register_tests_tool(mcp, token=None)
+        tool = mcp.tools[f"{TOOLS_PREFIX}_tests"]
+        result = asyncio.run(tool("failure_criteria_meta", {}, ctx=None))
+        assert result.error is None
+        payload = result.result[0]
+        assert "top_level_tool_args" in payload
+        assert "general" in payload and "kpis" in payload and "conditions" in payload
+        assert "general_labels" in payload

--- a/tests/test_required_args_tools.py
+++ b/tests/test_required_args_tools.py
@@ -88,6 +88,21 @@ class TestRequiredArgumentsForTools:
         assert result.error is not None
         assert "file_paths" in result.error
 
+    def test_tests_configure_failure_criteria_requires_enabled_and_rules(self):
+        mcp = FakeMcp()
+        register_tests_tool(mcp, token=None)
+        tool = mcp.tools[f"{TOOLS_PREFIX}_tests"]
+
+        result = asyncio.run(tool("configure_failure_criteria", {"test_id": 123}, ctx=None))
+        assert result.error is not None
+        assert "enabled" in result.error
+
+        result = asyncio.run(
+            tool("configure_failure_criteria", {"test_id": 123, "enabled": True}, ctx=None)
+        )
+        assert result.error is not None
+        assert "rules" in result.error
+
     def test_execution_read_requires_execution_id(self):
         mcp = FakeMcp()
         register_execution_tool(mcp, token=None)

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -27,7 +27,12 @@ from config.blazemeter import TESTS_ENDPOINT, TOOLS_PREFIX
 from config.path_mapper import PathMapperFactory
 from config.security import detect_sensitive_upload_path_reason
 from config.token import BzmToken
+from formatters.failure_criteria_labels import failure_criteria_meta_payload
 from formatters.test import format_tests
+from models.failure_criteria import (
+    failure_criteria_from_configure_args,
+    merge_failure_criteria_into_configuration_dict,
+)
 from models.manager import Manager
 from models.performance_test import PerformanceTestObject
 from models.result import BaseResult
@@ -423,6 +428,37 @@ class TestManager(Manager):
             result_formatter=format_tests,
             json=configuration_body)
 
+    @require_confirmation(operation=Operations.UPDATE)
+    async def configure_failure_criteria(self, args: Dict[str, Any]) -> BaseResult:
+        """Replace failure criteria for a test via PATCH configuration (preserves plugins.jmeter)."""
+        test_id = args.get("test_id")
+        if not isinstance(test_id, int) or test_id < 1:
+            return BaseResult(error="Missing or invalid required argument 'test_id'. Expected integer.")
+        try:
+            fc = failure_criteria_from_configure_args(args)
+        except ValueError as e:
+            return BaseResult(error=str(e))
+
+        test_data = await self.read(test_id)
+        if test_data.error:
+            return test_data
+
+        configuration = test_data.result[0].configuration
+        if not isinstance(configuration, dict):
+            configuration = {}
+        merged_configuration = merge_failure_criteria_into_configuration_dict(configuration, fc)
+        return await api_request(
+            self.token,
+            "PATCH",
+            f"{TESTS_ENDPOINT}/{test_id}",
+            result_formatter=format_tests,
+            json={"configuration": merged_configuration},
+        )
+
+    async def failure_criteria_meta(self, args: Dict[str, Any]) -> BaseResult:
+        """Return the full KPI and condition catalog for building configure_failure_criteria rules (no API call)."""
+        return BaseResult(result=[failure_criteria_meta_payload()])
+
 
 def register(mcp, token: Optional[BzmToken]):
     @mcp.tool(
@@ -433,6 +469,7 @@ Actions:
 - read: Read a test. Get the detailed information of a test.
     args(dict): Dictionary with the following required parameters:
         test_id (int): The only required parameter. The id of the test to read.
+    When presenting failure_criteria to the user, use meta.general_labels, meta.rule_field_labels, meta.kpi_labels, and meta.condition_labels for readable text; avoid leading with raw kpi ids or op codes.
 - create: Create a new test. Do not create a test if the user has not confirmed the location for validation of workspace, project and account.
     args(dict): Dictionary with the following required parameters:
         test_name (str): The required name of the test to create.
@@ -445,6 +482,7 @@ Actions:
         project_id (int): The id of the project to list tests from.
         limit (int, default=10, valid=[1 to 50]): The number of tests to list.
         offset (int, default=0): Number of tests to skip.
+    Each listed test may include failure_criteria; when describing it to the user, use meta labels like read (see read action).
 - configure_load: Configure the load of a test for the given test id. The test id is the only required parameter. 
              The test will be configured based on the following parameters only if user confirms the configuration:
     args(dict): Dictionary with the following parameters:
@@ -465,8 +503,40 @@ Actions:
         test_id (int): The id of the test to upload assets to.
         file_paths (list): List of full file paths to upload.
         main_script (str, optional): Path to the main script file. If provided, will update test configuration to use this script.
+- failure_criteria_meta: Read-only catalog: overview (layers), top_level_tool_args, rule_fields, general, general_labels, rule_field_labels, kpis, conditions. Field names align with reading and configuring tests. No BlazeMeter API call.
+    args(dict): Optional; may be empty {}. Unknown keys are ignored.
+- configure_failure_criteria: Set failure criteria (BlazeMeter configuration.enableFailureCriteria and configuration.plugins.thresholds). Replaces the full rules list for the test.
+    args(dict): Dictionary with the following parameters:
+        test_id (int): Required. The test id.
+        enabled (bool): Required. Master switch for the Failure Criteria section (API enableFailureCriteria).
+        rules (list): Required. List of rule objects; use an empty list to clear all rules. Each object may include:
+            kpi (str): Required per rule. API metric field name (`field`). Documented values (product may offer more):
+                responseTime.avg, responseTime.min, responseTime.max, responseTime.std,
+                responseTime.percentile.0, responseTime.percentile.50, responseTime.percentile.90,
+                responseTime.percentile.95, responseTime.percentile.99,
+                latency.avg, connectTime.avg, size.count, size.avg, size.rate,
+                hits.count, hits.avg, hits.rate, duration.count,
+                errors.count, errors.percent, errors.rate
+            label (str, default=ALL): Label scope for the metric (default ALL labels).
+            condition (str or null): API operator (`op`). Allowed string values:
+                lt (Less than), gt (Greater than), eq (Equal to), ne (Not equal to),
+                lte (Less than or equal to), gte (Greater than or equal to).
+                Omit the key or use JSON null for no operator (incomplete / initial state).
+            value (str): Threshold as string (numeric text, e.g. "500", "1"; may be empty until set).
+            offset_percent (str, default=0.0): Baseline offset percentage string (API offsetPercentage).
+            stop_test_on_violation (bool, default=false): Stop Test on violation (API stopTestOnViolation); product expects 1-min slide window when used.
+            sliding_window (bool, default=false): 1-min slide window eval for this rule (API slidingWindow). Per-row "1-min slide window eval"; bulk "Enable 1-min slide window eval for all" means every rule has sliding_window true.
+            ignore_rampup (bool, optional): Per-rule ignore ramp-up when the API includes it on the item.
+            is_empty (bool, default=false): Incomplete row flag (API isEmpty).
+        ignore_rampup (bool, optional): Container-level "Ignore failure criteria during ramp-up" (advanced); omit to keep existing value on merge.
+        sliding_window_for_all (bool, optional): If set, sets every rule's sliding_window to this value after parsing rules (bulk convenience).
+        from_taurus (bool, optional): plugins.thresholds.fromTaurus; omit to preserve existing.
+        criteria_overridden_in_interface (bool, optional): Threshold-block metadata (maps to plugins.thresholds when merging); omit to preserve existing.
+    Reading a test and configuring failure criteria use the same field names; BlazeMeter’s REST JSON is only used in HTTP calls inside the server.
 Hints:
 - **CRITICAL**: Always follow the action schema exactly. If args are required, include args with exact names/types.
+- Before configure_failure_criteria, prefer failure_criteria_meta for kpi/condition codes and labels, then read if you must merge with existing rules.
+- For configure_failure_criteria, call read first and merge client-side if you must keep existing rules; providing rules replaces all criteria rows for that test.
 """
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
@@ -496,6 +566,10 @@ Hints:
                     if isinstance(upload_result, dict) and upload_result.get("error"):
                         return BaseResult(error=upload_result["error"])
                     return BaseResult(result=[upload_result])
+                case "configure_failure_criteria":
+                    return await test_manager.configure_failure_criteria(args)
+                case "failure_criteria_meta":
+                    return await test_manager.failure_criteria_meta(args)
                 case _:
                     return BaseResult(
                         error=f"Action {action} not found in tests manager tool"


### PR DESCRIPTION
This pull request introduces a comprehensive domain model and formatting utilities for BlazeMeter failure criteria, integrating them into the test formatting pipeline. The main additions are the new `models/failure_criteria.py` and `formatters/failure_criteria_labels.py` modules, which provide structured representations and label catalogs for failure criteria, as well as conversion logic between API and tool formats. The `Test` model and test formatting logic are updated to include a `failure_criteria` field with rich metadata, and the main program instructions now clarify how failure criteria fields and labels should be handled.

**Failure Criteria Domain Model and Formatting Integration**

*New failure criteria domain model and API conversion:*
- Added `models/failure_criteria.py` containing `FailureCriteriaConfig` and `FailureCriterionRule` classes, with methods to parse, validate, and serialize failure criteria between API and tool formats. Includes logic for merging criteria into test configurations and validating configuration arguments.

*Failure criteria field and label catalogs:*
- Added `formatters/failure_criteria_labels.py` providing static and dynamic field definitions, label mappings for KPIs and operators, and functions to generate metadata payloads for UI/display.

*Test model and formatting updates:*
- Updated the `Test` model to include a `failure_criteria` field with both criteria and display metadata.
- Updated `formatters/test.py` to extract failure criteria from test configurations, parse them into the domain model, and format them (with metadata) for inclusion in each `Test`. [[1]](diffhunk://#diff-2dd3ecc764313cc3ed76bde60732fe365e9c259bf51ae8b46aa627fd6842ca99L16-R79) [[2]](diffhunk://#diff-2dd3ecc764313cc3ed76bde60732fe365e9c259bf51ae8b46aa627fd6842ca99L33-R92)

**User Guidance and Tooling Instructions**

*Main program instructions:*
- Clarified in `main.py` that the same field names are used for reading and configuring failure criteria, and that label maps (`meta.general_labels`, etc.) should be used for user-facing descriptions. Emphasized the need for explicit user confirmation before modifying failure criteria. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1L129-R129) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R153)