### PR TITLE
Fix dist binary publication

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,16 +4,15 @@ on:
   workflow_run:
     workflows: ["Tests"]
     types: [completed]
-    branches: ['main']
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         include:
@@ -82,75 +81,3 @@ jobs:
       with:
         name: bzm-mcp-${{ matrix.name }}-${{ matrix.arch }}
         path: dist/
-
-  commit-artifacts:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-    # Use REPO_PUSH_PAT (user PAT with bypass allowance) to push dist/ to main when branch protection blocks GITHUB_TOKEN.
-    - uses: actions/checkout@v6
-      with:
-        token: ${{ secrets.REPO_PUSH_PAT || secrets.GITHUB_TOKEN }}
-
-    - name: Download all artifacts
-      uses: actions/download-artifact@v7
-      with:
-        path: artifacts/
-    
-    - name: Organize artifacts into dist/
-      shell: bash
-      run: |
-        mkdir -p dist/
-        # Copy all binaries from artifact directories to dist/ 
-        # upload-artifacts job does not preserve the executable permission
-        # so we need to set it manually: https://github.com/actions/download-artifact?tab=readme-ov-file#limitations
-
-        if [ -d "artifacts/bzm-mcp-linux-amd64" ]; then
-          cp artifacts/bzm-mcp-linux-amd64/* dist/
-          chmod +x dist/bzm-mcp-linux-amd64
-          echo "Copied Linux AMD64 binary"
-        fi
-        if [ -d "artifacts/bzm-mcp-linux-arm64" ]; then
-          cp artifacts/bzm-mcp-linux-arm64/* dist/
-          chmod +x dist/bzm-mcp-linux-arm64
-          echo "Copied Linux ARM64 binary"
-        fi
-        if [ -d "artifacts/bzm-mcp-windows-amd64" ]; then
-          cp artifacts/bzm-mcp-windows-amd64/* dist/
-          echo "Copied Windows AMD64 binary"
-        fi
-        if [ -d "artifacts/bzm-mcp-macos-arm64" ]; then
-          cp -r artifacts/bzm-mcp-macos-arm64/* dist/
-          if [ -d "dist/bzm-mcp-arm64.app" ]; then
-            echo "Found macOS ARM64 .app bundle"
-          else
-            chmod +x dist/bzm-mcp-macos-arm64 2>/dev/null || true
-            echo "Copied macOS ARM64 binary"
-          fi
-        fi
-        if [ -d "artifacts/bzm-mcp-macos-amd64" ]; then
-          cp -r artifacts/bzm-mcp-macos-amd64/* dist/
-          if [ -d "dist/bzm-mcp-amd64.app" ]; then
-            echo "Found macOS AMD64 .app bundle"
-          else
-            chmod +x dist/bzm-mcp-macos-amd64 2>/dev/null || true
-            echo "Copied macOS AMD64 binary"
-          fi
-        fi
-
-        echo "Final dist/ contents:"
-        ls -la dist/ || echo "No dist/ directory found"
-    
-    - name: Commit all artifacts to repository
-      shell: bash
-      run: |
-        git config --local user.email "actions@github.com"
-        git config --local user.name "GitHub Actions"
-        git add dist/
-        if git diff --staged --quiet; then
-          echo "No changes to commit"
-        else
-          git commit -m "[skip ci] Update all binary artifacts"
-          git push
-        fi

--- a/.github/workflows/commit-dist.yaml
+++ b/.github/workflows/commit-dist.yaml
@@ -1,0 +1,85 @@
+name: Commit Dist Artifacts
+
+# Publishes binaries built by "Build Binaries" back into dist/ on main.
+
+on:
+  workflow_run:
+    workflows: ["Build Binaries"]
+    types: [completed]
+    branches: ['main']
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  commit-artifacts:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        token: ${{ secrets.REPO_PUSH_PAT || secrets.GITHUB_TOKEN }}
+
+    - name: Download all artifacts from triggering Build Binaries run
+      uses: actions/download-artifact@v7
+      with:
+        path: artifacts/
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Organize artifacts into dist/
+      shell: bash
+      run: |
+        mkdir -p dist/
+        # upload-artifact does not preserve the executable bit, so reapply it manually:
+        # https://github.com/actions/download-artifact?tab=readme-ov-file#limitations
+
+        if [ -d "artifacts/bzm-mcp-linux-amd64" ]; then
+          cp artifacts/bzm-mcp-linux-amd64/* dist/
+          chmod +x dist/bzm-mcp-linux-amd64
+          echo "Copied Linux AMD64 binary"
+        fi
+        if [ -d "artifacts/bzm-mcp-linux-arm64" ]; then
+          cp artifacts/bzm-mcp-linux-arm64/* dist/
+          chmod +x dist/bzm-mcp-linux-arm64
+          echo "Copied Linux ARM64 binary"
+        fi
+        if [ -d "artifacts/bzm-mcp-windows-amd64" ]; then
+          cp artifacts/bzm-mcp-windows-amd64/* dist/
+          echo "Copied Windows AMD64 binary"
+        fi
+        if [ -d "artifacts/bzm-mcp-macos-arm64" ]; then
+          cp -r artifacts/bzm-mcp-macos-arm64/* dist/
+          if [ -d "dist/bzm-mcp-arm64.app" ]; then
+            echo "Found macOS ARM64 .app bundle"
+          else
+            chmod +x dist/bzm-mcp-macos-arm64 2>/dev/null || true
+            echo "Copied macOS ARM64 binary"
+          fi
+        fi
+        if [ -d "artifacts/bzm-mcp-macos-amd64" ]; then
+          cp -r artifacts/bzm-mcp-macos-amd64/* dist/
+          if [ -d "dist/bzm-mcp-amd64.app" ]; then
+            echo "Found macOS AMD64 .app bundle"
+          else
+            chmod +x dist/bzm-mcp-macos-amd64 2>/dev/null || true
+            echo "Copied macOS AMD64 binary"
+          fi
+        fi
+
+        echo "Final dist/ contents:"
+        ls -la dist/ || echo "No dist/ directory found"
+
+    - name: Commit all artifacts to repository
+      shell: bash
+      run: |
+        git config --local user.email "actions@github.com"
+        git config --local user.name "GitHub Actions"
+        git add dist/
+        if git diff --staged --quiet; then
+          echo "No changes to commit"
+        else
+          git commit -m "[skip ci] Update all binary artifacts"
+          git push
+        fi


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflows related to building and publishing binary artifacts. The main change is the extraction of the artifact commit logic into a dedicated workflow, improving separation of concerns and maintainability. Additionally, permissions and triggering conditions have been clarified.

**Workflow refactoring and separation:**

* Moved the logic for committing built binaries from the `build.yaml` workflow into a new, dedicated workflow file `commit-dist.yaml`, which is triggered only after successful runs of the "Build Binaries" workflow on the `main` branch. [[1]](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L85-L156) [[2]](diffhunk://#diff-20680364e18efb61f2a027c66636ed9ff17d07f0526ee4822d70285862c3f57aR1-R85)

**Permissions and triggers:**

* Changed the `contents` permission in `build.yaml` from `write` to `read` since it no longer needs to commit artifacts, and clarified the workflow triggers and job conditions for better security and intent.

**Artifact handling improvements:**

* Updated the artifact download step in the new workflow to use the correct `run-id` and `github-token`, ensuring only artifacts from the triggering workflow run are used.
* Ensured that executable permissions are reapplied to binaries after downloading artifacts, addressing a known limitation of the GitHub Actions `download-artifact` action.