### PR TITLE
Otel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN chmod +x ./bzm-mcp && \
 USER bzm-mcp
 
 ENV MCP_DOCKER=true
-ENV OTEL_EXPORTER_OTLP_ENDPOINT=""
+# Telemetry defaults to the Perforce gRPC collector. Override the destination
+# with OTEL_EXPORTER_OTLP_ENDPOINT, or set OTEL_SDK_DISABLED=true to turn it off.
 
 # Command to run the application
 ENTRYPOINT ["./bzm-mcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN chmod +x ./bzm-mcp && \
 USER bzm-mcp
 
 ENV MCP_DOCKER=true
+ENV OTEL_EXPORTER_OTLP_ENDPOINT=""
 
 # Command to run the application
 ENTRYPOINT ["./bzm-mcp"]

--- a/build.py
+++ b/build.py
@@ -114,6 +114,15 @@ def run_pyinstaller(name: str, icon: str):
         f'--icon={icon}',
         '--clean',
         '--noconfirm',
+        '--hidden-import=opentelemetry.sdk.trace',
+        '--hidden-import=opentelemetry.sdk.trace.export',
+        '--hidden-import=opentelemetry.sdk.resources',
+        '--hidden-import=opentelemetry.sdk.metrics',
+        '--hidden-import=opentelemetry.sdk.metrics.export',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.http.trace_exporter',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.http.metric_exporter',
+        '--hidden-import=opentelemetry.propagate',
+        '--collect-submodules=opentelemetry',
     ])
 
 

--- a/build.py
+++ b/build.py
@@ -119,10 +119,11 @@ def run_pyinstaller(name: str, icon: str):
         '--hidden-import=opentelemetry.sdk.resources',
         '--hidden-import=opentelemetry.sdk.metrics',
         '--hidden-import=opentelemetry.sdk.metrics.export',
-        '--hidden-import=opentelemetry.exporter.otlp.proto.http.trace_exporter',
-        '--hidden-import=opentelemetry.exporter.otlp.proto.http.metric_exporter',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.grpc.trace_exporter',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.grpc.metric_exporter',
         '--hidden-import=opentelemetry.propagate',
         '--collect-submodules=opentelemetry',
+        '--collect-all=grpc',
     ])
 
 

--- a/build.py
+++ b/build.py
@@ -121,6 +121,8 @@ def run_pyinstaller(name: str, icon: str):
         '--hidden-import=opentelemetry.sdk.metrics.export',
         '--hidden-import=opentelemetry.exporter.otlp.proto.grpc.trace_exporter',
         '--hidden-import=opentelemetry.exporter.otlp.proto.grpc.metric_exporter',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.http.trace_exporter',
+        '--hidden-import=opentelemetry.exporter.otlp.proto.http.metric_exporter',
         '--hidden-import=opentelemetry.propagate',
         '--collect-submodules=opentelemetry',
         '--collect-all=grpc',

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ from mcp.server.fastmcp import FastMCP
 from config.token import BzmToken, BzmTokenError
 from config.version import __version__, __executable__, __bundle__
 from server import register_tools
+from telemetry import init_telemetry
 from tools.utils import ConfirmMode, register_confirm_mode
 
 BLAZEMETER_API_KEY_FILE_PATH = os.getenv('BLAZEMETER_API_KEY')
@@ -373,6 +374,7 @@ def get_token():
 
 
 def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE):
+    init_telemetry("bzm-mcp", __version__)
     token = get_token()
     instructions = """
 # BlazeMeter MCP Server
@@ -473,7 +475,35 @@ def main():
         )
     )
 
+    otel_group = parser.add_argument_group("telemetry", "OpenTelemetry settings (override env vars)")
+    otel_group.add_argument(
+        "--otel-endpoint",
+        metavar="URL",
+        help="OTLP collector endpoint URL (overrides OTEL_EXPORTER_OTLP_ENDPOINT)",
+    )
+    otel_group.add_argument(
+        "--otel-headers",
+        metavar="KEY=VALUE",
+        action="append",
+        help=(
+            "OTLP header (repeatable, e.g. --otel-headers Authorization=Bearer\\ token); "
+            "overrides OTEL_EXPORTER_OTLP_HEADERS"
+        ),
+    )
+    otel_group.add_argument(
+        "--no-telemetry",
+        action="store_true",
+        help="Disable all OpenTelemetry tracing and metrics (sets OTEL_SDK_DISABLED=true)",
+    )
+
     args = parser.parse_args()
+
+    if args.no_telemetry:
+        os.environ["OTEL_SDK_DISABLED"] = "true"
+    if args.otel_endpoint:
+        os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = args.otel_endpoint
+    if args.otel_headers:
+        os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = ",".join(args.otel_headers)
 
     if args.mcp:
         init_logging(args.log_level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,9 @@ requires-python = ">=3.11"
 dependencies = [
     "httpx[http2]>=0.28.1",
     "mcp[cli]>=1.27.0",
+    "opentelemetry-api>=1.20.0",
+    "opentelemetry-sdk>=1.20.0",
+    "opentelemetry-exporter-otlp>=1.20.0",
     "pyjwt>=2.12.0",
     "starlette>=0.47.3",
     "pyinstaller>=6.17.0",
@@ -20,7 +23,7 @@ dependencies = [
 bzm-mcp = "main:main"
 
 [tool.setuptools]
-py-modules = ["main", "server"]
+py-modules = ["main", "server", "telemetry"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/telemetry.py
+++ b/telemetry.py
@@ -15,7 +15,6 @@ limitations under the License.
 """
 import logging
 import os
-import platform
 import time
 from typing import Any, Awaitable, Callable
 
@@ -33,6 +32,13 @@ except ImportError:
 
 _call_counter = None
 _duration_histogram = None
+
+# Perforce MCP telemetry mandate: shipped releases export to the Perforce OTLP
+# collector over gRPC. Used only when OTEL_EXPORTER_OTLP_ENDPOINT is not set.
+# Transport is always gRPC (never OTLP/HTTP); OTEL_EXPORTER_OTLP_ENDPOINT overrides
+# only the destination URL — an http:// scheme means an insecure (no-TLS) channel.
+# See: https://github.com/Blazemeter/sv-mcp/commit/27236587303333eb525452d63f4f66ce9296cca2
+DEFAULT_OTLP_ENDPOINT = "https://grpc.public.prd.shared.perforce.com"
 
 
 def init_telemetry(service_name: str, service_version: str) -> None:
@@ -52,35 +58,34 @@ def init_telemetry(service_name: str, service_version: str) -> None:
         resource = Resource.create({
             SERVICE_NAME: service_name,
             SERVICE_VERSION: service_version,
-            "os.type": platform.system().lower(),
-            "host.arch": platform.machine().lower(),
         })
         provider = TracerProvider(resource=resource)
 
-        endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
-        if endpoint:
-            try:
-                from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-                provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
-            except Exception:
-                logger.debug("OTLP trace exporter setup failed", exc_info=True)
+        # Default the export destination to the Perforce gRPC collector. Users
+        # override only the endpoint via OTEL_EXPORTER_OTLP_ENDPOINT;
+        # OTEL_SDK_DISABLED=true (or --no-telemetry) turns tracing off entirely.
+        if not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+            os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = DEFAULT_OTLP_ENDPOINT
+
+        try:
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        except Exception:
+            logger.debug("OTLP trace exporter setup failed", exc_info=True)
 
         trace.set_tracer_provider(provider)
         logger.debug("OTel TracerProvider initialised (service=%s, version=%s)", service_name, service_version)
 
         try:
-            # Metrics SDK is optional relative to tracing; keep imports local so a
-            # missing metrics package does not prevent trace provider setup.
             from opentelemetry.sdk.metrics import MeterProvider
             from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
             readers = []
-            if endpoint:
-                try:
-                    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-                    readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
-                except Exception:
-                    logger.debug("OTLP metric exporter setup failed", exc_info=True)
+            try:
+                from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+                readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
+            except Exception:
+                logger.debug("OTLP metric exporter setup failed", exc_info=True)
 
             meter_provider = MeterProvider(resource=resource, metric_readers=readers)
             metrics.set_meter_provider(meter_provider)

--- a/telemetry.py
+++ b/telemetry.py
@@ -34,6 +34,27 @@ _call_counter = None
 _duration_histogram = None
 
 DEFAULT_OTLP_ENDPOINT = "https://grpc.public.prd.shared.perforce.com"
+DEFAULT_OTLP_PROTOCOL = "grpc"
+
+
+def _get_otlp_protocol() -> str:
+    return os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", DEFAULT_OTLP_PROTOCOL)
+
+
+def _create_trace_exporter():
+    if _get_otlp_protocol() == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    else:
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    return OTLPSpanExporter()
+
+
+def _create_metric_exporter():
+    if _get_otlp_protocol() == "grpc":
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    else:
+        from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+    return OTLPMetricExporter()
 
 
 def init_telemetry(service_name: str, service_version: str) -> None:
@@ -56,15 +77,14 @@ def init_telemetry(service_name: str, service_version: str) -> None:
         })
         provider = TracerProvider(resource=resource)
 
-        # Default the export destination to the Perforce gRPC collector. Users
-        # override only the endpoint via OTEL_EXPORTER_OTLP_ENDPOINT;
-        # OTEL_SDK_DISABLED=true (or --no-telemetry) turns tracing off entirely.
+        # Default export destination/protocol for shipped releases (gRPC + Perforce
+        # collector). PAG or local dev may override via OTEL_EXPORTER_OTLP_ENDPOINT
+        # and OTEL_EXPORTER_OTLP_PROTOCOL; OTEL_SDK_DISABLED=true disables telemetry.
         if not os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
             os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = DEFAULT_OTLP_ENDPOINT
 
         try:
-            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-            provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+            provider.add_span_processor(BatchSpanProcessor(_create_trace_exporter()))
         except Exception:
             logger.debug("OTLP trace exporter setup failed", exc_info=True)
 
@@ -77,8 +97,7 @@ def init_telemetry(service_name: str, service_version: str) -> None:
 
             readers = []
             try:
-                from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
-                readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
+                readers.append(PeriodicExportingMetricReader(_create_metric_exporter()))
             except Exception:
                 logger.debug("OTLP metric exporter setup failed", exc_info=True)
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -43,6 +43,8 @@ def init_telemetry(service_name: str, service_version: str) -> None:
     if os.getenv("OTEL_SDK_DISABLED", "").lower() == "true":
         return
     try:
+        # Lazy SDK imports: defer heavy setup until init_telemetry() and tolerate a
+        # missing SDK (ImportError) without breaking module import or startup.
         from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -67,6 +69,8 @@ def init_telemetry(service_name: str, service_version: str) -> None:
         logger.debug("OTel TracerProvider initialised (service=%s, version=%s)", service_name, service_version)
 
         try:
+            # Metrics SDK is optional relative to tracing; keep imports local so a
+            # missing metrics package does not prevent trace provider setup.
             from opentelemetry.sdk.metrics import MeterProvider
             from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
@@ -166,8 +170,10 @@ def _http_status_to_error_type(status_code: int) -> str:
     return f"http_{status_code}"
 
 
-def _record_metrics(tool_name: str, action: str, elapsed: float, outcome: str) -> None:
-    attrs = {"gen_ai.tool.name": tool_name, "mcp.tool.action": action, "error.type": outcome}
+def _record_metrics(tool_name: str, action: str, elapsed: float, error_type: str | None) -> None:
+    attrs: dict[str, str] = {"gen_ai.tool.name": tool_name, "mcp.tool.action": action}
+    if error_type is not None:
+        attrs["error.type"] = error_type
     try:
         if _call_counter is not None:
             _call_counter.add(1, attrs)
@@ -236,10 +242,10 @@ async def run_tool(
             raise
         finally:
             elapsed = time.perf_counter() - start
-            outcome = error_type or (
-                "api_error" if result is not None and getattr(result, "error", None) else "ok"
+            metric_error_type = error_type or (
+                "api_error" if result is not None and getattr(result, "error", None) else None
             )
-            _record_metrics(tool_name, action, elapsed, outcome)
+            _record_metrics(tool_name, action, elapsed, metric_error_type)
 
         if result is not None and getattr(result, "error", None):
             _record_span_error(span, "api_error")

--- a/telemetry.py
+++ b/telemetry.py
@@ -33,11 +33,6 @@ except ImportError:
 _call_counter = None
 _duration_histogram = None
 
-# Perforce MCP telemetry mandate: shipped releases export to the Perforce OTLP
-# collector over gRPC. Used only when OTEL_EXPORTER_OTLP_ENDPOINT is not set.
-# Transport is always gRPC (never OTLP/HTTP); OTEL_EXPORTER_OTLP_ENDPOINT overrides
-# only the destination URL — an http:// scheme means an insecure (no-TLS) channel.
-# See: https://github.com/Blazemeter/sv-mcp/commit/27236587303333eb525452d63f4f66ce9296cca2
 DEFAULT_OTLP_ENDPOINT = "https://grpc.public.prd.shared.perforce.com"
 
 

--- a/telemetry.py
+++ b/telemetry.py
@@ -1,0 +1,246 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import logging
+import os
+import platform
+import time
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+try:
+    from opentelemetry import metrics, trace  # noqa: F401 — must be module-level for patching
+    _OTEL_API_AVAILABLE = True
+except ImportError:
+    trace = None  # type: ignore[assignment]
+    metrics = None  # type: ignore[assignment]
+    _OTEL_API_AVAILABLE = False
+
+_call_counter = None
+_duration_histogram = None
+
+
+def init_telemetry(service_name: str, service_version: str) -> None:
+    global _call_counter, _duration_histogram
+
+    if not _OTEL_API_AVAILABLE:
+        return
+    if os.getenv("OTEL_SDK_DISABLED", "").lower() == "true":
+        return
+    try:
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+        resource = Resource.create({
+            SERVICE_NAME: service_name,
+            SERVICE_VERSION: service_version,
+            "os.type": platform.system().lower(),
+            "host.arch": platform.machine().lower(),
+        })
+        provider = TracerProvider(resource=resource)
+
+        endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+        if endpoint:
+            try:
+                from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+                provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+            except Exception:
+                logger.debug("OTLP trace exporter setup failed", exc_info=True)
+
+        trace.set_tracer_provider(provider)
+        logger.debug("OTel TracerProvider initialised (service=%s, version=%s)", service_name, service_version)
+
+        try:
+            from opentelemetry.sdk.metrics import MeterProvider
+            from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+
+            readers = []
+            if endpoint:
+                try:
+                    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+                    readers.append(PeriodicExportingMetricReader(OTLPMetricExporter()))
+                except Exception:
+                    logger.debug("OTLP metric exporter setup failed", exc_info=True)
+
+            meter_provider = MeterProvider(resource=resource, metric_readers=readers)
+            metrics.set_meter_provider(meter_provider)
+
+            meter = metrics.get_meter("bzm-mcp")
+            _call_counter = meter.create_counter(
+                "mcp.tool.calls",
+                unit="{call}",
+                description="Number of MCP tool calls",
+            )
+            _duration_histogram = meter.create_histogram(
+                "mcp.tool.duration",
+                unit="s",
+                description="MCP tool call duration in seconds",
+            )
+            logger.debug("OTel MeterProvider initialised")
+        except ImportError:
+            pass
+        except Exception:
+            logger.debug("OTel metrics init failed", exc_info=True)
+
+    except ImportError:
+        pass
+    except Exception:
+        logger.debug("OTel init failed; continuing without tracing", exc_info=True)
+
+
+def _get_meta(ctx: Any) -> dict:
+    try:
+        return ctx.request_context.request.params.meta or {}
+    except Exception:
+        return {}
+
+
+def _extract_trace_context(meta: dict):
+    if not meta:
+        return None
+    try:
+        from opentelemetry.propagate import extract
+        carrier = {}
+        if "traceparent" in meta:
+            carrier["traceparent"] = meta["traceparent"]
+        if "tracestate" in meta:
+            carrier["tracestate"] = meta["tracestate"]
+        return extract(carrier) if carrier else None
+    except Exception:
+        return None
+
+
+def _get_client_info(ctx: Any):
+    try:
+        info = ctx.request_context.session.client_params.clientInfo
+        return info.name, info.version
+    except Exception:
+        return None, None
+
+
+def _get_session_id(ctx: Any) -> str | None:
+    try:
+        session_id = ctx.session_id
+        return str(session_id) if session_id is not None else None
+    except Exception:
+        return None
+
+
+def _record_span_error(span: Any, error_type: str) -> None:
+    try:
+        span.set_attribute("error.type", error_type)
+    except Exception:
+        pass
+    try:
+        from opentelemetry.trace import Status, StatusCode
+        span.set_status(Status(StatusCode.ERROR))
+    except Exception:
+        pass
+
+
+def _http_status_to_error_type(status_code: int) -> str:
+    if status_code in (401, 403):
+        return "auth_failed"
+    if status_code == 404:
+        return "not_found"
+    if status_code == 429:
+        return "rate_limited"
+    if status_code >= 500:
+        return "server_error"
+    return f"http_{status_code}"
+
+
+def _record_metrics(tool_name: str, action: str, elapsed: float, outcome: str) -> None:
+    attrs = {"gen_ai.tool.name": tool_name, "mcp.tool.action": action, "error.type": outcome}
+    try:
+        if _call_counter is not None:
+            _call_counter.add(1, attrs)
+        if _duration_histogram is not None:
+            _duration_histogram.record(elapsed, attrs)
+    except Exception:
+        pass
+
+
+async def run_tool(
+    tool_name: str,
+    action: str,
+    ctx: Any,
+    dispatch: Callable[[], Awaitable[Any]],
+) -> Any:
+    if trace is None:
+        return await dispatch()
+
+    try:
+        meta = _get_meta(ctx)
+        parent_ctx = _extract_trace_context(meta)
+        tracer = trace.get_tracer("bzm-mcp")
+        span_cm = tracer.start_as_current_span(
+            f"tools/call {tool_name}",
+            context=parent_ctx,
+            kind=trace.SpanKind.SERVER,
+            record_exception=False,
+            set_status_on_exception=False,
+        )
+    except Exception:
+        return await dispatch()
+
+    with span_cm as span:
+        try:
+            span.set_attribute("mcp.method.name", "tools/call")
+            span.set_attribute("gen_ai.tool.name", tool_name)
+            span.set_attribute("gen_ai.operation.name", "execute_tool")
+            span.set_attribute("mcp.tool.action", action)
+            client_name, client_version = _get_client_info(ctx)
+            if client_name is not None:
+                span.set_attribute("user_agent.name", client_name)
+            if client_version is not None:
+                span.set_attribute("user_agent.version", client_version)
+            session_id = _get_session_id(ctx)
+            if session_id is not None:
+                span.set_attribute("mcp.session.id", session_id)
+        except Exception:
+            pass
+
+        start = time.perf_counter()
+        error_type: str | None = None
+        result = None
+        try:
+            result = await dispatch()
+        except httpx.TimeoutException:
+            error_type = "timeout"
+            _record_span_error(span, error_type)
+            raise
+        except httpx.HTTPStatusError as e:
+            error_type = _http_status_to_error_type(e.response.status_code)
+            _record_span_error(span, error_type)
+            raise
+        except Exception:
+            error_type = "tool_error"
+            _record_span_error(span, error_type)
+            raise
+        finally:
+            elapsed = time.perf_counter() - start
+            outcome = error_type or (
+                "api_error" if result is not None and getattr(result, "error", None) else "ok"
+            )
+            _record_metrics(tool_name, action, elapsed, outcome)
+
+        if result is not None and getattr(result, "error", None):
+            _record_span_error(span, "api_error")
+        return result

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -20,7 +20,7 @@ import httpx
 import pytest
 
 from models.result import BaseResult
-from telemetry import init_telemetry, run_tool
+from telemetry import _record_metrics, init_telemetry, run_tool
 
 
 def _make_ctx(meta=None):
@@ -48,6 +48,30 @@ def _make_tracer_and_span():
     tracer = MagicMock()
     tracer.start_as_current_span.return_value = cm
     return tracer, span
+
+
+class TestRecordMetrics:
+    def test_omits_error_type_on_success(self):
+        counter = MagicMock()
+        histogram = MagicMock()
+        with patch("telemetry._call_counter", counter), patch("telemetry._duration_histogram", histogram):
+            _record_metrics("blazemeter_user", "read", 0.5, None)
+        expected = {"gen_ai.tool.name": "blazemeter_user", "mcp.tool.action": "read"}
+        counter.add.assert_called_once_with(1, expected)
+        histogram.record.assert_called_once_with(0.5, expected)
+
+    def test_includes_error_type_on_failure(self):
+        counter = MagicMock()
+        histogram = MagicMock()
+        with patch("telemetry._call_counter", counter), patch("telemetry._duration_histogram", histogram):
+            _record_metrics("blazemeter_user", "read", 0.5, "timeout")
+        expected = {
+            "gen_ai.tool.name": "blazemeter_user",
+            "mcp.tool.action": "read",
+            "error.type": "timeout",
+        }
+        counter.add.assert_called_once_with(1, expected)
+        histogram.record.assert_called_once_with(0.5, expected)
 
 
 class TestRunTool:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -21,7 +21,16 @@ import httpx
 import pytest
 
 from models.result import BaseResult
-from telemetry import DEFAULT_OTLP_ENDPOINT, _record_metrics, init_telemetry, run_tool
+from telemetry import (
+    DEFAULT_OTLP_ENDPOINT,
+    DEFAULT_OTLP_PROTOCOL,
+    _create_metric_exporter,
+    _create_trace_exporter,
+    _get_otlp_protocol,
+    _record_metrics,
+    init_telemetry,
+    run_tool,
+)
 
 
 def _make_ctx(meta=None):
@@ -232,3 +241,53 @@ class TestInitTelemetry:
         monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
         init_telemetry("bzm-mcp", "1.0.0")
         assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"
+
+    def test_defaults_protocol_to_grpc(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
+        assert _get_otlp_protocol() == DEFAULT_OTLP_PROTOCOL
+        assert DEFAULT_OTLP_PROTOCOL == "grpc"
+
+    def test_http_protocol_env(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        assert _get_otlp_protocol() == "http/protobuf"
+
+    def test_does_not_raise_with_http_protocol(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+        init_telemetry("bzm-mcp", "1.0.0")
+
+    def test_grpc_trace_exporter_selected(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        with patch(
+            "opentelemetry.exporter.otlp.proto.grpc.trace_exporter.OTLPSpanExporter",
+            return_value=MagicMock(),
+        ) as grpc_exporter:
+            _create_trace_exporter()
+        grpc_exporter.assert_called_once()
+
+    def test_http_trace_exporter_selected(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+        with patch(
+            "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter",
+            return_value=MagicMock(),
+        ) as http_exporter:
+            _create_trace_exporter()
+        http_exporter.assert_called_once()
+
+    def test_grpc_metric_exporter_selected(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+        with patch(
+            "opentelemetry.exporter.otlp.proto.grpc.metric_exporter.OTLPMetricExporter",
+            return_value=MagicMock(),
+        ) as grpc_exporter:
+            _create_metric_exporter()
+        grpc_exporter.assert_called_once()
+
+    def test_http_metric_exporter_selected(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/json")
+        with patch(
+            "opentelemetry.exporter.otlp.proto.http.metric_exporter.OTLPMetricExporter",
+            return_value=MagicMock(),
+        ) as http_exporter:
+            _create_metric_exporter()
+        http_exporter.assert_called_once()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,196 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from models.result import BaseResult
+from telemetry import init_telemetry, run_tool
+
+
+def _make_ctx(meta=None):
+    ctx = MagicMock()
+    ctx.request_context.request.params.meta = meta or {}
+    ctx.request_context.session.client_params = None
+    ctx.session_id = None
+    return ctx
+
+
+def _make_ctx_with_client(name="claude-code", version="1.2.3"):
+    ctx = MagicMock()
+    ctx.request_context.request.params.meta = {}
+    ctx.request_context.session.client_params.clientInfo.name = name
+    ctx.request_context.session.client_params.clientInfo.version = version
+    ctx.session_id = "session-abc"
+    return ctx
+
+
+def _make_tracer_and_span():
+    span = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=span)
+    cm.__exit__ = MagicMock(return_value=False)
+    tracer = MagicMock()
+    tracer.start_as_current_span.return_value = cm
+    return tracer, span
+
+
+class TestRunTool:
+    def test_returns_dispatch_result(self):
+        ctx = _make_ctx()
+        tracer, _ = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            result = BaseResult(result=[{"id": 1}])
+            returned = asyncio.run(run_tool("blazemeter_user", "read", ctx, AsyncMock(return_value=result)))
+            assert returned is result
+
+    def test_sets_span_attributes(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            asyncio.run(run_tool("blazemeter_user", "read", ctx, AsyncMock(return_value=BaseResult())))
+            span.set_attribute.assert_any_call("gen_ai.tool.name", "blazemeter_user")
+            span.set_attribute.assert_any_call("mcp.tool.action", "read")
+            span.set_attribute.assert_any_call("mcp.method.name", "tools/call")
+            span.set_attribute.assert_any_call("gen_ai.operation.name", "execute_tool")
+
+    def test_sets_client_info_attributes(self):
+        ctx = _make_ctx_with_client("claude-code", "1.2.3")
+        tracer, span = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            asyncio.run(run_tool("blazemeter_user", "read", ctx, AsyncMock(return_value=BaseResult())))
+            span.set_attribute.assert_any_call("user_agent.name", "claude-code")
+            span.set_attribute.assert_any_call("user_agent.version", "1.2.3")
+            span.set_attribute.assert_any_call("mcp.session.id", "session-abc")
+
+    def test_span_kind_server(self):
+        ctx = _make_ctx()
+        tracer, _ = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            asyncio.run(run_tool("blazemeter_user", "read", ctx, AsyncMock(return_value=BaseResult())))
+            _, kwargs = tracer.start_as_current_span.call_args
+            assert kwargs.get("kind") == t.SpanKind.SERVER
+
+    def test_reraises_httpx_401(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        response = MagicMock()
+        response.status_code = 401
+        err = httpx.HTTPStatusError("unauthorized", request=MagicMock(), response=response)
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            with pytest.raises(httpx.HTTPStatusError):
+                asyncio.run(run_tool("t", "a", ctx, AsyncMock(side_effect=err)))
+            span.set_attribute.assert_any_call("error.type", "auth_failed")
+
+    def test_reraises_httpx_404(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        response = MagicMock()
+        response.status_code = 404
+        err = httpx.HTTPStatusError("not found", request=MagicMock(), response=response)
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            with pytest.raises(httpx.HTTPStatusError):
+                asyncio.run(run_tool("t", "a", ctx, AsyncMock(side_effect=err)))
+            span.set_attribute.assert_any_call("error.type", "not_found")
+
+    def test_reraises_httpx_500(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        response = MagicMock()
+        response.status_code = 500
+        err = httpx.HTTPStatusError("server error", request=MagicMock(), response=response)
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            with pytest.raises(httpx.HTTPStatusError):
+                asyncio.run(run_tool("t", "a", ctx, AsyncMock(side_effect=err)))
+            span.set_attribute.assert_any_call("error.type", "server_error")
+
+    def test_reraises_httpx_timeout(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        err = httpx.TimeoutException("timed out")
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            with pytest.raises(httpx.TimeoutException):
+                asyncio.run(run_tool("t", "a", ctx, AsyncMock(side_effect=err)))
+            span.set_attribute.assert_any_call("error.type", "timeout")
+
+    def test_reraises_generic_exception(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            with pytest.raises(ValueError):
+                asyncio.run(run_tool("t", "a", ctx, AsyncMock(side_effect=ValueError("boom"))))
+            span.set_attribute.assert_any_call("error.type", "tool_error")
+
+    def test_marks_span_failed_on_result_error(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            result = BaseResult(error="api returned error")
+            returned = asyncio.run(run_tool("t", "a", ctx, AsyncMock(return_value=result)))
+            assert returned is result
+            span.set_attribute.assert_any_call("error.type", "api_error")
+
+    def test_survives_span_setup_failure(self):
+        ctx = _make_ctx()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.side_effect = RuntimeError("otel broken")
+            result = BaseResult(result=[{"id": 1}])
+            returned = asyncio.run(run_tool("t", "a", ctx, AsyncMock(return_value=result)))
+            assert returned is result
+
+    def test_survives_broken_ctx(self):
+        ctx = _make_ctx(meta=None)
+        tracer, _ = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            result = BaseResult(result=[])
+            returned = asyncio.run(run_tool("t", "a", ctx, AsyncMock(return_value=result)))
+            assert returned is result
+
+    def test_omits_client_info_when_absent(self):
+        ctx = _make_ctx()
+        tracer, span = _make_tracer_and_span()
+        with patch("telemetry.trace") as t:
+            t.get_tracer.return_value = tracer
+            asyncio.run(run_tool("blazemeter_user", "read", ctx, AsyncMock(return_value=BaseResult())))
+            attribute_names = [c[0][0] for c in span.set_attribute.call_args_list]
+            assert "user_agent.name" not in attribute_names
+            assert "user_agent.version" not in attribute_names
+
+
+class TestInitTelemetry:
+    def test_does_not_raise_without_sdk(self):
+        init_telemetry("bzm-mcp", "1.0.0")
+
+    def test_does_not_raise_with_disabled_flag(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        init_telemetry("bzm-mcp", "1.0.0")
+
+    def test_does_not_raise_with_endpoint_set(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+        init_telemetry("bzm-mcp", "1.0.0")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -14,13 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import asyncio
+import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
 from models.result import BaseResult
-from telemetry import _record_metrics, init_telemetry, run_tool
+from telemetry import DEFAULT_OTLP_ENDPOINT, _record_metrics, init_telemetry, run_tool
 
 
 def _make_ctx(meta=None):
@@ -216,5 +217,18 @@ class TestInitTelemetry:
         init_telemetry("bzm-mcp", "1.0.0")
 
     def test_does_not_raise_with_endpoint_set(self, monkeypatch):
-        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
         init_telemetry("bzm-mcp", "1.0.0")
+
+    def test_defaults_endpoint_to_perforce_grpc(self, monkeypatch):
+        monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+        monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+        init_telemetry("bzm-mcp", "1.0.0")
+        assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == DEFAULT_OTLP_ENDPOINT
+        assert DEFAULT_OTLP_ENDPOINT == "https://grpc.public.prd.shared.perforce.com"
+
+    def test_explicit_endpoint_not_overridden(self, monkeypatch):
+        monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+        monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+        init_telemetry("bzm-mcp", "1.0.0")
+        assert os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://localhost:4317"

--- a/tools/account_manager.py
+++ b/tools/account_manager.py
@@ -22,6 +22,7 @@ from config.token import BzmToken
 from formatters.account import format_accounts
 from models.manager import Manager
 from models.result import BaseResult
+from telemetry import run_tool
 from tools.utils import api_request, format_sanitized_traceback
 
 
@@ -97,7 +98,8 @@ Hints:
     )
     async def account(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         account_manager = AccountManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "read":
                     return await account_manager.read(args.get("account_id"))
@@ -107,6 +109,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in account manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_account", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/billing_manager.py
+++ b/tools/billing_manager.py
@@ -23,6 +23,7 @@ from config.token import BzmToken
 from models.manager import Manager
 from models.result import BaseResult
 from tools.billing_utils import calculate_test_cost
+from telemetry import run_tool
 from tools.utils import format_sanitized_traceback
 
 
@@ -87,7 +88,8 @@ Hints:
     )
     async def billing(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         billing_manager = BillingManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "calculate_cost_from_config":
                     return await billing_manager.calculate_cost_from_config(args)
@@ -95,6 +97,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in billing manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_billing", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -25,6 +25,7 @@ from models.manager import Manager
 from models.result import BaseResult
 from tools import bridge, search_utils
 from tools.report_manager import ReportManager
+from telemetry import run_tool
 from tools.utils import api_request, timeout, user_agent, format_sanitized_traceback, require_confirmation, Operations
 
 
@@ -498,7 +499,7 @@ Hints:
         execution_manager = ExecutionManager(token, ctx)
         report_manager = ReportManager(token, ctx)
 
-        try:
+        async def _dispatch():
             match action:
                 case "start":
                     return await execution_manager.start(args.get("test_id"))
@@ -531,6 +532,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in test execution manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_execution", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/help_manager.py
+++ b/tools/help_manager.py
@@ -29,6 +29,7 @@ from formatters.help import format_help_info
 from models.manager import Manager
 from models.result import BaseResult
 from tools.help_utils import convert_js_to_py_dict
+from telemetry import run_tool
 from tools.utils import http_request, format_sanitized_traceback
 
 
@@ -290,7 +291,8 @@ Hints:
             args = {}
 
         help_manager = HelpManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "list_help_categories":
                     return await help_manager.list_help_categories()
@@ -345,6 +347,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in help manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_help", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/project_manager.py
+++ b/tools/project_manager.py
@@ -24,6 +24,7 @@ from formatters.project import format_projects
 from models.manager import Manager
 from models.result import BaseResult
 from tools import bridge
+from telemetry import run_tool
 from tools.utils import api_request, format_sanitized_traceback
 
 
@@ -105,7 +106,8 @@ Hints:
     )
     async def project(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         project_manager = ProjectManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "read":
                     return await project_manager.read(args.get("project_id"))
@@ -115,6 +117,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in project manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_project", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/skills_manager.py
+++ b/tools/skills_manager.py
@@ -25,6 +25,7 @@ from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE
 from config.token import BzmToken
 from models.manager import Manager
 from models.result import BaseResult
+from telemetry import run_tool
 from tools.utils import format_sanitized_traceback
 from tools.skills_utils import list_skills, read_skill_definition, read_skill_file, parse_skill_uri, \
     is_skill_uri, list_skill_resources_uri
@@ -203,7 +204,8 @@ Hints:
             args = {}
 
         skills_manager = SkillsManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "list_skills":
                     return await skills_manager.list_skills()
@@ -251,6 +253,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in skills manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_skills", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -37,6 +37,7 @@ from models.manager import Manager
 from models.performance_test import PerformanceTestObject
 from models.result import BaseResult
 from tools import bridge, search_utils
+from telemetry import run_tool
 from tools.utils import (
     api_request,
     require_confirmation,
@@ -653,7 +654,8 @@ Hints:
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         test_manager = TestManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "read":
                     return await test_manager.read(args.get("test_id"))
@@ -698,6 +700,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in tests manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_tests", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(error=f"Error: {format_sanitized_traceback()}")
         except Exception:

--- a/tools/user_manager.py
+++ b/tools/user_manager.py
@@ -24,6 +24,7 @@ from config.token import BzmToken
 from formatters.user import format_users
 from models.manager import Manager
 from models.result import BaseResult
+from telemetry import run_tool
 from tools.utils import api_request, format_sanitized_traceback
 
 
@@ -60,7 +61,8 @@ Hints:
     ) -> BaseResult:
 
         user_manager = UserManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "read":
                     return await user_manager.read()
@@ -68,6 +70,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in user manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_user", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/tools/workspace_manager.py
+++ b/tools/workspace_manager.py
@@ -25,6 +25,7 @@ from formatters.workspace import format_workspaces, format_workspaces_detailed, 
 from models.manager import Manager
 from models.result import BaseResult
 from tools import bridge
+from telemetry import run_tool
 from tools.utils import api_request, format_sanitized_traceback
 
 
@@ -138,7 +139,8 @@ Hints:
     ) -> BaseResult:
 
         workspace_manager = WorkspaceManager(token, ctx)
-        try:
+
+        async def _dispatch():
             match action:
                 case "read":
                     return await workspace_manager.read(args.get("workspace_id"))
@@ -152,6 +154,9 @@ Hints:
                     return BaseResult(
                         error=f"Action {action} not found in workspace manager tool"
                     )
+
+        try:
+            return await run_tool(f"{TOOLS_PREFIX}_workspaces", action, ctx, _dispatch)
         except httpx.HTTPStatusError:
             return BaseResult(
                 error=f"Error: {format_sanitized_traceback()}"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,11 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "altgraph"
@@ -59,6 +64,9 @@ dependencies = [
     { name = "httpx", extra = ["http2"] },
     { name = "lxml" },
     { name = "mcp", extra = ["cli"] },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-sdk" },
     { name = "pydantic" },
     { name = "pydantic-core" },
     { name = "pydantic-settings" },
@@ -77,6 +85,9 @@ requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=5.3.0" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
+    { name = "opentelemetry-api", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.20.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-core", specifier = ">=2.33.2" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
@@ -168,6 +179,95 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -245,6 +345,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
     { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/a8/9916ab10a0201f4c7afb6918125aa2f38a7626ee18ffbc066dd9cb04a74d/grpcio-1.81.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:794e6aa648e8df47d8f908dc8c3b42347d04ec58438f1dcd4e445f09b4f6b0ce", size = 6093557, upload-time = "2026-06-01T05:54:32.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/43/99e969a048904a65df3129ee53c5f523b7c4e43127786460cac4bee82470/grpcio-1.81.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:cd78145b7f7784661c524624f3526c9c6f891b30a4b54cb93a40806d0d0d61e9", size = 12075345, upload-time = "2026-06-01T05:54:35.77Z" },
+    { url = "https://files.pythonhosted.org/packages/83/70/4c3a204e190333768d4f63f4ff56bd0bf405f05b9188f3a59a8bcf161f8b/grpcio-1.81.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:638ccc1b86f7540170a169cb900799b9296a1381e47879ce60b0de9d3db73d33", size = 6640664, upload-time = "2026-06-01T05:54:38.854Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a9/0fa17ac8b4e29cf59b26915be6cab8c0d4583ce24a6208a287b6e5f6d072/grpcio-1.81.0-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:21ec30b9ea320c8207ea7cd05873ad64aa69fdd0e81b6758b3347983ba20b50a", size = 7332542, upload-time = "2026-06-01T05:54:41.39Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/18/7c8e3d0dda2fb7a17076fcd6c9085209eabad3354696c64230f87b3a14eb/grpcio-1.81.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:dbdb99986548a7e87f8343805ef315fd4eb50ffaabf4fb1206e42f2542bb805d", size = 6842564, upload-time = "2026-06-01T05:54:43.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/19/2f1726c2e03ad3f3fe241e6b41534532ad580d595de14a4054ad84999c80/grpcio-1.81.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c36f5d5e97944cbda2d4096b4ae262e6e68506246b61582acf1b8591607f3ccc", size = 7446236, upload-time = "2026-06-01T05:54:46.042Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/dc/0321f892212e2c0bfe248cea24c00d7d7111639688ec5ffd8e36b5c02fe6/grpcio-1.81.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:9f355384e5543ab77a755a7085225ecc19f32b76032e851cbd8145715d79dec8", size = 8445633, upload-time = "2026-06-01T05:54:48.809Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/20/0e7ea7494955cf1beea3077b2fd2c04c84d4480c2ae85a1e1cfa150c62d7/grpcio-1.81.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:77eb4e9fe61486bd1198cc7236ebb0f70e66234e63c0348f40bc2553ed16a88b", size = 7873958, upload-time = "2026-06-01T05:54:52.135Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/6438e226046c2a0778060e2b1d791a4827277bbd9d223013c2c63ee7435e/grpcio-1.81.0-cp311-cp311-win32.whl", hash = "sha256:7915a2e63acdc05264a206e1bddfd8e1fb8a29e406c18d72d30f8c124e021374", size = 4202110, upload-time = "2026-06-01T05:54:54.134Z" },
+    { url = "https://files.pythonhosted.org/packages/42/6b/d0895e93d65b186f5f1737fcc186d7faa487e2d9d934eda111a37a309869/grpcio-1.81.0-cp311-cp311-win_amd64.whl", hash = "sha256:5e925a70fe99fe5794f7beca0ea034c75f068afcc356d79047e73f99cdcca34c", size = 4940942, upload-time = "2026-06-01T05:54:56.749Z" },
+    { url = "https://files.pythonhosted.org/packages/82/d5/896a3aaf07068d707d88b282a04914b872db4d32d3c7e6d88e43a3b911fa/grpcio-1.81.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:57b3b0e73a518fa286959b40c3eddd02703504ca186e8b7b2945954519bd8b2c", size = 6053538, upload-time = "2026-06-01T05:54:58.965Z" },
+    { url = "https://files.pythonhosted.org/packages/68/6a/7e3eafa4727cd405ff917605ed2949e2af162f233f5cbdd773723a5fea7d/grpcio-1.81.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8bb1789c94322a13336a2b6c58d9c14d68f8628b6e24205a799c69f5bf8516ce", size = 12053447, upload-time = "2026-06-01T05:55:01.862Z" },
+    { url = "https://files.pythonhosted.org/packages/16/79/a4302aa82428de48a922421f522b027a1a727ab4d0926368454aa953d36d/grpcio-1.81.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e4d053900a0d24b75d7521139a3872150301b3d6bde3bed5e12318fb25791e4d", size = 6595872, upload-time = "2026-06-01T05:55:04.946Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/1f/7ff2850eaefbecf99af3f624dbb28dd1ad6c5fd4c1d8c26909ed6482673b/grpcio-1.81.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:db217c2e52931719f9937bd12082cd4d7b495b35803d5760686975c285924bf8", size = 7303857, upload-time = "2026-06-01T05:55:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/98/1f3896a9baae1f2aedf4e99c55291d6fa1f30ad9603d63bc18bda967b53e/grpcio-1.81.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19f201da7b4e5c0559198abe5a97157e726f3abe6e8f5e832d4a50740f6dcc22", size = 6809676, upload-time = "2026-06-01T05:55:09.513Z" },
+    { url = "https://files.pythonhosted.org/packages/34/8b/3441983718095208c5d797fd3239882e97ea89a629f41c8df94b4eef4df9/grpcio-1.81.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:275144b0115353339dbb8a6f28a9cf8997b5bf40e37f8f66ac0b0ea57e95b43f", size = 7412654, upload-time = "2026-06-01T05:55:12.777Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/98/1eddf07df6e4fe85cf67502a793f7b05468b2dca3d1ef35b972cf5d54468/grpcio-1.81.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5192857589f223e5a98ff0e31f6e551b19040e647d17bfe10116c8a2ce3b8696", size = 8408026, upload-time = "2026-06-01T05:55:15.514Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/73/3860341e6a1f5347be6ab35c6c0e1e3a8eb59d010388207fd561dcf01a88/grpcio-1.81.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c6ff087cb1f563f47b504b4e29e684129fc5ae4863faf3ebca08a327764ee6cb", size = 7849498, upload-time = "2026-06-01T05:55:18.078Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3f/0ea06bd85c701966aa3f8f37314f2ed83520d2b7590f42d643d445d8bc8b/grpcio-1.81.0-cp312-cp312-win32.whl", hash = "sha256:98c6240f563178fc5877bd50e6ff274463e53e1472128f4110742450739659fa", size = 4184161, upload-time = "2026-06-01T05:55:20.127Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e3/a7c387406827a86f99ad7838b995bf9b4a182ffe2d2c439ed2873efec952/grpcio-1.81.0-cp312-cp312-win_amd64.whl", hash = "sha256:87e33b7afcfb3585121b5f007d2c52b8c534104d18f556e840d35193ca2a9141", size = 4929958, upload-time = "2026-06-01T05:55:22.736Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/29/779ee53c931d0fd55c1d459fde43e485172caa3ac87cbd43d003a13a0185/grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855", size = 6054973, upload-time = "2026-06-01T05:55:25.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b6/7211807926b5a17f8d9a5d47c739a163d6812fefe3e4714e81cf92945ed7/grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719", size = 12048662, upload-time = "2026-06-01T05:55:28.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/89/b1b93ef6b34bd20bbaf707fa99133bc9cc302139d5ec6f77a165c7169796/grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901", size = 6599116, upload-time = "2026-06-01T05:55:31.185Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bc/c89f9b9d1c22895715356a1e009554dae66319e97826bb4d30bcda7d29e8/grpcio-1.81.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8c0855a350886f713b9e458e2a10d208009dcaa849f574e39cd6067db1fe1279", size = 7307591, upload-time = "2026-06-01T05:55:33.463Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4a/1df2a4cb4a1386e066ab7e4175e34bb884b35ccb60d3621c09c84af6aabb/grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170", size = 6811797, upload-time = "2026-06-01T05:55:36.731Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/dc/fa189d20601a1be25b08850cfb733879bbb1047b62a8feec3a60e3e1a87b/grpcio-1.81.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7746ba3e6efc9e2b748eff59470a2b8684d5a9ec607c6580bcaa5be175820bc", size = 7415131, upload-time = "2026-06-01T05:55:39.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/5625c48cb48d23c6631b3e5294f88e4c751f22a52591ae78859fab96dca1/grpcio-1.81.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:aaaa4f7f2057d795952e4eacf3f342be8b5b156992f6ac85023c8b98794ebd47", size = 8408398, upload-time = "2026-06-01T05:55:42.219Z" },
+    { url = "https://files.pythonhosted.org/packages/75/34/0f8202c6809a46c2b4d69125ef3667c40b1c211f8e19930e5fa1f1197039/grpcio-1.81.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fba53cb96004b2b7fb758b46b2288cb49d0b658316a4e73f3ef67230616ee65", size = 7844481, upload-time = "2026-06-01T05:55:44.849Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/95/c3366b5b5edf4c4adc90f2e29ca16e57965a8e56dc8d2ee89565ba1905bb/grpcio-1.81.0-cp313-cp313-win32.whl", hash = "sha256:c197e2ef75a442528072b29e9755da299110e8610e8bcbb59a6b4cf55384f005", size = 4182777, upload-time = "2026-06-01T05:55:47.459Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a7/932f2f748511a32e641a2aba0d30dded3ed6e8bc330e0924e4d5d86853e6/grpcio-1.81.0-cp313-cp313-win_amd64.whl", hash = "sha256:194eddfacc84d80f50512e9fd4ee851d5f2499f18f299c95aa8fb4748f0537e0", size = 4928085, upload-time = "2026-06-01T05:55:50.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1d/28b231333857deb840bc3d182ae087510170ea6d68f21393aeb0fe499530/grpcio-1.81.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:a9351055f52660b58f3d4890ea66188b5134399f82b11aa0c55bd4b99eff5390", size = 6055712, upload-time = "2026-06-01T05:55:52.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b8/999c14f9dff0fc47549d2e827cba1343ddc18e1d1bf0d06d2cf628eecbd9/grpcio-1.81.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:300f3337b6425fd16ead9a4f9b2ac25801acb64aa5bc0b99eb69901645b2b1d2", size = 12057189, upload-time = "2026-06-01T05:55:55.952Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3d/1fbde079572562af65351151d840525a13879eb7b481d35b55cd64c6127a/grpcio-1.81.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:97bbd623f7ded558fd4f7cb5a4f600c4d4de65c5dd364c83a5b14b2a10a2d3b5", size = 6608136, upload-time = "2026-06-01T05:55:59.069Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/1f17cb6882abfd8e5a303a25d5d1665abef5a8c499a96198c65a651d1b85/grpcio-1.81.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ff83d889e3ebf6341c8c7864ad8031591ad5ca61599072fc511644d1eb962d2b", size = 7307045, upload-time = "2026-06-01T05:56:02.376Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/f98e91b2e755652e637ea2144318b0229b290062199f761b445fe1fa6015/grpcio-1.81.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4fe218c5a35e1d87a5a26544237f1fa41dfd9cbd3c856b0810a30061f8b0aaf", size = 6812794, upload-time = "2026-06-01T05:56:05.777Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/77892d715ac41e7ec0ace2a50080ffb64e189188056f607a66fe0014d1ee/grpcio-1.81.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b8b025b6af43ee0ad4a70307025d77bcab5adde7c4597786010d802c203e9fc5", size = 7422767, upload-time = "2026-06-01T05:56:08.524Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b8/aa04590c6564714d94954515f15a236e59d4b9b3ad01e615f1b706d7792d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3d4e0ce5a40a998cf608c8ba60ecfe18fdf364a9aa193ae4ac3faeecd0e86757", size = 8408551, upload-time = "2026-06-01T05:56:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
 ]
 
 [[package]]
@@ -541,6 +704,118 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/1c/125e1c936c0873796771b7f04f6c93b9f1bf5d424cea90fda94a99f61da8/opentelemetry_api-1.42.1.tar.gz", hash = "sha256:56c63bea9f77b62856be8c47600474acad853b2924b99b1687c4cb6297166716", size = 72296, upload-time = "2026-05-21T16:32:49.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/ca/9520cc1f3dfbbd03ac5903bbf55833e257bc64b1cf30fa8b0d6df374d821/opentelemetry_api-1.42.1-py3-none-any.whl", hash = "sha256:51a69edacadbc03a8950ace1c4c21099cacc538820ac2c9e36277e78cebba714", size = 61311, upload-time = "2026-05-21T16:32:28.822Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/94/8637919a5d01f81dacf510234bc0110b944f4687a6e96b0a02adf2f6bdce/opentelemetry_exporter_otlp-1.42.1.tar.gz", hash = "sha256:2d9ebaed714377a67d224d46795ddcc11d2c877fa5de35fda70b6f3b010729a9", size = 6086, upload-time = "2026-05-21T16:32:51.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/4d/c26080295a36fd22e201fefd7cb9c22cd203189b1af8cd73b158382b7ad8/opentelemetry_exporter_otlp-1.42.1-py3-none-any.whl", hash = "sha256:aedd54545bb0587cd45210abdc8be545af9c01413f3307786e276df1e3c83bee", size = 6733, upload-time = "2026-05-21T16:32:31.261Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/9c/216acfeaedadf2e1937f4373929b20f73197c5c4a2546d4f584b7fa63813/opentelemetry_exporter_otlp_proto_common-1.42.1.tar.gz", hash = "sha256:04f1f01fb597c4249dfcd7f8b861c902c2102369d376d9d346ff38de4469a2ee", size = 21433, upload-time = "2026-05-21T16:32:55.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d6/43/2375e7612e1121a4518c17603b6e0b03ad94f565aafad53f464dc5be2bf6/opentelemetry_exporter_otlp_proto_common-1.42.1-py3-none-any.whl", hash = "sha256:f48d395ab815b444da118868977e9798ea354c25737d5cf39578ae894011c140", size = 17327, upload-time = "2026-05-21T16:32:33.387Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/87/ca7fc790dfdbcf4f9e9aab14a39ef1b7508ead13707e283de0b3131478d2/opentelemetry_exporter_otlp_proto_grpc-1.42.1.tar.gz", hash = "sha256:975c4461f167dd8ed8857d68d3b6b25f3d272eab896f6a9470d0f5b90e2faf15", size = 27140, upload-time = "2026-05-21T16:32:56.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/2b/28ba5b128f47fe8c3bab541000d6feb4b5a9bd26623ca013406f01c0fb60/opentelemetry_exporter_otlp_proto_grpc-1.42.1-py3-none-any.whl", hash = "sha256:0ae1177e2038b18a929b3098215243631ef91136cba26b7e2b12790ceb7e87cc", size = 19617, upload-time = "2026-05-21T16:32:34.278Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/32/826bfa1d80ecea24f47808de03cd4a0d13c17ecc07712f45123f0f61e4ac/opentelemetry_exporter_otlp_proto_http-1.42.1.tar.gz", hash = "sha256:bf142a21035d7571ac3a09cb2e5639f49886f243972883cfe777ed3bf02b734d", size = 25406, upload-time = "2026-05-21T16:32:56.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/96/82cb223a1502f0787d4bbff12907f5f8d870a50731febcd5818d93ef9555/opentelemetry_exporter_otlp_proto_http-1.42.1-py3-none-any.whl", hash = "sha256:00a16da1b312a1d6c7233d600d557c91df71125af73020f3b9a7765bd699d59d", size = 21793, upload-time = "2026-05-21T16:32:35.277Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/55/63eac3e1089b768ba014091fdd2ae8a9a440c821ef5e2b786909c94c8836/opentelemetry_proto-1.42.1.tar.gz", hash = "sha256:c6a51e6b4f05ae63565f3a113217f3d2bfaec68f78c02d7a6c85f9010d1cfca6", size = 45839, upload-time = "2026-05-21T16:33:03.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/9d/171c02c84a76940b7e601805b3bb536985aded9168fbcc9ba52f0a730fa2/opentelemetry_proto-1.42.1-py3-none-any.whl", hash = "sha256:dedb74cba2886c59c7789b227a7a670613025a07489040050aedff6e5c0fb43c", size = 71782, upload-time = "2026-05-21T16:32:44.867Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.42.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f7/b390bd9bfd703bf98a68fea1f27786c6872331fd617164a54b8a59bdc008/opentelemetry_sdk-1.42.1.tar.gz", hash = "sha256:8c834e8f8c9ba4171d4ec843d0cb8a67e4c7394d3f9e9297e582cbd9456ddbf7", size = 239262, upload-time = "2026-05-21T16:33:04.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/6b/4287766cfbde577ae2272e8884abac325aeaac0d64f41c61d5b8cc595105/opentelemetry_sdk-1.42.1-py3-none-any.whl", hash = "sha256:083cd4bbfaa5aa7b5a9e552430d9951219967cfb27aa61feb13a77aba1fc839d", size = 170907, upload-time = "2026-05-21T16:32:45.894Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.63b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/99/4d7dd6df64795951413ce6e815f8cf1eb191daf7196ae86574589643d5f3/opentelemetry_semantic_conventions-0.63b1.tar.gz", hash = "sha256:3daf963611334b365e98a57438183eb012d3bfb40b2d931a9af613476b8701a9", size = 148340, upload-time = "2026-05-21T16:33:05.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/7a/7fe66f5f3682b1dd47d88cc4e11f1c6c0966b737de2d16671146e23c39a5/opentelemetry_semantic_conventions-0.63b1-py3-none-any.whl", hash = "sha256:dfe5ef4dee82586b746f522b818ceb298d00b3d59f660042bd79404bff8d0682", size = 203713, upload-time = "2026-05-21T16:32:47.016Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.1"
 source = { registry = "https://pypi.org/simple" }
@@ -565,6 +840,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -848,6 +1138,21 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1046,6 +1351,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces OpenTelemetry-based tracing and metrics to the MCP server, allowing for improved observability of tool calls. It adds a new `telemetry.py` module with integration points, updates dependencies, and provides configuration options via command-line arguments and environment variables. The changes are covered by comprehensive tests.

**OpenTelemetry Telemetry Integration:**

* Added a new `telemetry.py` module that initializes OpenTelemetry tracing and metrics, records tool call spans and metrics, and provides a `run_tool` wrapper for instrumenting tool actions. (`telemetry.py` [telemetry.pyR1-R252](diffhunk://#diff-7ca3202a240fd222989331d01a63488d8c9530fc5e6369a1fab80f4ed5832c50R1-R252))
* Updated `tools/account_manager.py` to wrap tool execution with `run_tool`, enabling automatic telemetry for account-related tool actions. [[1]](diffhunk://#diff-a01336caabebbcfd04e4e5624d5c8717ad715b1ef744c56de29f30aea403c733R25) [[2]](diffhunk://#diff-a01336caabebbcfd04e4e5624d5c8717ad715b1ef744c56de29f30aea403c733L100-R102) [[3]](diffhunk://#diff-a01336caabebbcfd04e4e5624d5c8717ad715b1ef744c56de29f30aea403c733R112-R114)

**Configuration and CLI enhancements:**

* Added OpenTelemetry-related command-line arguments (`--otel-endpoint`, `--otel-headers`, `--no-telemetry`) to `main.py`, allowing users to configure telemetry exporters or disable telemetry. These override environment variables.
* Set a default `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in the `Dockerfile` for containerized deployments.

**Dependency and packaging updates:**

* Added OpenTelemetry dependencies (`opentelemetry-api`, `opentelemetry-sdk`, `opentelemetry-exporter-otlp`) to `pyproject.toml` and included the new `telemetry` module in the package. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R10-R12) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L23-R26)
* Updated `build.py` to ensure PyInstaller includes all necessary OpenTelemetry modules and submodules for packaging.

**Testing:**

* Added `tests/test_telemetry.py` with unit tests for telemetry initialization, metrics recording, and the `run_tool` wrapper, including error handling and context propagation.

**Integration points:**

* Imported and initialized telemetry in `main.py` during server startup, ensuring telemetry is active if not explicitly disabled. [[1]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R35) [[2]](diffhunk://#diff-b10564ab7d2c520cdd0243874879fb0a782862c3c902ab535faabe57d5a505e1R377)

These changes provide robust, configurable, and well-tested telemetry support for the MCP server, facilitating improved monitoring and debugging.