### PR TITLE
Upgrade ubuntu image to latest lts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,19 +35,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     
-    - name: Build binary (Linux in Ubuntu 25.10 container)
+    - name: Build binary (Linux in Ubuntu 26.04 container)
       if: matrix.name == 'linux'
       shell: bash
       run: |
-        # Docker container with Ubuntu 25.10 and build the binary inside it
+        # Docker container with Ubuntu 26.04 and build the binary inside it
         rm -rf dist/*
         docker run --rm \
           -v "$PWD:/workspace" \
           -w /workspace \
-          ubuntu:25.10 \
+          ubuntu:26.04 \
           bash -c "
             set -e
-            echo 'Setting up Ubuntu 25.10 build environment...'
+            echo 'Setting up Ubuntu 26.04 build environment...'
             
             apt-get update -y
             apt-get install -y --fix-missing curl python3 python3-pip python3-venv binutils

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:25.10
+FROM ubuntu:26.04
 
 
 WORKDIR /app


### PR DESCRIPTION
This pull request updates the build environment to use Ubuntu 26.04 instead of Ubuntu 25.10. This change ensures that both the Docker build and the GitHub Actions workflow are aligned with the latest supported base image.

**Build environment update:**

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L15-R15): Changed the base image from `ubuntu:25.10` to `ubuntu:26.04` to use a more recent Ubuntu release.
* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1L38-R50): Updated the build step to use an Ubuntu 26.04 container instead of 25.10, including all related comments and messages.