### PR TITLE
Mob 50409 connect over streamable http

### DIFF
--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from tools.utils import ConfirmMode, register_confirm_mode
 BLAZEMETER_API_KEY_FILE_PATH = os.getenv('BLAZEMETER_API_KEY')
 
 LOG_LEVELS = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+MCP_TRANSPORTS = ("stdio", "http", "docker")
 
 # Canonical server label for printed JSON and clients that accept arbitrary string ids.
 MCP_SERVER_DISPLAY_NAME = "BlazeMeter MCP"
@@ -373,7 +374,37 @@ def get_token():
     return token
 
 
-def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE):
+def resolve_mcp_transport(raw_cli_transport: str) -> str:
+    """
+    Resolve transport with precedence: CLI > BZM_MCP_TRANSPORT > stdio.
+
+    `raw_cli_transport` comes from argparse `--mcp`:
+    - empty string means `--mcp` was provided without an explicit value
+    - non-empty string means an explicit CLI transport was provided
+    """
+    raw_cli_transport = raw_cli_transport.strip()
+
+    if raw_cli_transport:
+        candidate = raw_cli_transport
+        source = "CLI --mcp"
+    else:
+        candidate = os.getenv("BZM_MCP_TRANSPORT", "").strip()
+        source = "BZM_MCP_TRANSPORT"
+
+    if not candidate:
+        return "stdio"
+
+    normalized = candidate.lower()
+    if normalized not in MCP_TRANSPORTS:
+        allowed = ", ".join(MCP_TRANSPORTS)
+        raise ValueError(
+            f"Invalid MCP transport '{candidate}' from {source}. "
+            f"Valid values: {allowed}."
+        )
+    return normalized
+
+
+def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE, transport: str = "stdio"):
     init_telemetry("bzm-mcp", __version__)
     token = get_token()
     instructions = """
@@ -434,6 +465,9 @@ A comprehensive integration tool that provides AI assistants with full programma
     mcp = FastMCP("blazemeter-mcp", instructions=instructions, log_level=cast(LOG_LEVELS, log_level))
     register_confirm_mode(confirm_mode)
     register_tools(mcp, token)
+    if transport == "http":
+        mcp.run(transport="streamable-http")
+        return
     mcp.run(transport="stdio")
 
 
@@ -451,8 +485,13 @@ def main():
 
     parser.add_argument(
         "--mcp",
-        action="store_true",
-        help="Execute MCP Server"
+        nargs="?",
+        const="",
+        metavar="TRANSPORT",
+        help=(
+            "Execute MCP Server. Optional TRANSPORT values: stdio, http, docker.\n"
+            "Resolution precedence: CLI > BZM_MCP_TRANSPORT > stdio."
+        ),
     )
 
     parser.add_argument(
@@ -505,9 +544,13 @@ def main():
     if args.otel_headers:
         os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = ",".join(args.otel_headers)
 
-    if args.mcp:
+    if args.mcp is not None:
+        try:
+            transport = resolve_mcp_transport(args.mcp)
+        except ValueError as e:
+            parser.error(str(e))
         init_logging(args.log_level)
-        run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm])
+        run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm], transport=transport)
     else:
 
         logo_ascii = (

--- a/main.py
+++ b/main.py
@@ -411,6 +411,13 @@ def build_runtime(
 ) -> tuple[FastMCP, str]:
     init_telemetry("bzm-mcp", __version__)
     token = get_token()
+    host = "127.0.0.1"
+    port = 8000
+    streamable_http_path = "/mcp"
+    if transport == "http":
+        host = os.getenv("FASTMCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
+        port = int(os.getenv("FASTMCP_PORT", "8000").strip() or "8000")
+        streamable_http_path = os.getenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp").strip() or "/mcp"
     instructions = """
 # BlazeMeter MCP Server
 A comprehensive integration tool that provides AI assistants with full programmatic access to BlazeMeter's cloud-based performance testing platform. Enables automated management of complete load testing workflows from creation to execution and reporting. Transforms enterprise-grade testing capabilities into an AI-accessible service for intelligent automation of complex performance testing scenarios.
@@ -466,7 +473,15 @@ A comprehensive integration tool that provides AI assistants with full programma
 - **Proactive Troubleshooting**: Use the skills for troubleshooting any detected issues.
 - **Failure criteria**: The same field names appear when you read a test and when you configure failure criteria (`failure_criteria` on the test); the server handles BlazeMeter’s REST format internally. Use `failure_criteria_meta` for field definitions and KPI/condition catalogs. When describing criteria to the user, use `meta.general_labels`, `meta.rule_field_labels`, `meta.kpi_labels`, and `meta.condition_labels`; use raw metric and operator ids only inside tool calls. Use `configure_failure_criteria` only after user confirmation; it replaces all rules unless you merge from a prior read.
     """
-    mcp = FastMCP("blazemeter-mcp", instructions=instructions, log_level=cast(LOG_LEVELS, log_level))
+    mcp = FastMCP(
+        "blazemeter-mcp",
+        instructions=instructions,
+        log_level=cast(LOG_LEVELS, log_level),
+        host=host,
+        port=port,
+        streamable_http_path=streamable_http_path,
+        stateless_http=False,
+    )
     register_confirm_mode(confirm_mode)
     register_tools(mcp, token)
     runtime_transport = "streamable-http" if transport == "http" else "stdio"
@@ -558,10 +573,14 @@ def main():
     if args.mcp is not None:
         try:
             transport = resolve_mcp_transport(args.mcp)
+            if transport == "docker":
+                os.environ["MCP_DOCKER"] = "true"
+            elif transport == "http":
+                os.environ["MCP_DOCKER"] = "false"
+            init_logging(args.log_level)
+            run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm], transport=transport)
         except ValueError as e:
             parser.error(str(e))
-        init_logging(args.log_level)
-        run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm], transport=transport)
     else:
 
         logo_ascii = (

--- a/main.py
+++ b/main.py
@@ -404,7 +404,11 @@ def resolve_mcp_transport(raw_cli_transport: str) -> str:
     return normalized
 
 
-def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE, transport: str = "stdio"):
+def build_runtime(
+        log_level: str = "CRITICAL",
+        confirm_mode: ConfirmMode = ConfirmMode.DELETE,
+        transport: str = "stdio",
+) -> tuple[FastMCP, str]:
     init_telemetry("bzm-mcp", __version__)
     token = get_token()
     instructions = """
@@ -465,10 +469,17 @@ A comprehensive integration tool that provides AI assistants with full programma
     mcp = FastMCP("blazemeter-mcp", instructions=instructions, log_level=cast(LOG_LEVELS, log_level))
     register_confirm_mode(confirm_mode)
     register_tools(mcp, token)
-    if transport == "http":
-        mcp.run(transport="streamable-http")
-        return
-    mcp.run(transport="stdio")
+    runtime_transport = "streamable-http" if transport == "http" else "stdio"
+    return mcp, runtime_transport
+
+
+def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE, transport: str = "stdio"):
+    mcp, runtime_transport = build_runtime(
+        log_level=log_level,
+        confirm_mode=confirm_mode,
+        transport=transport,
+    )
+    mcp.run(transport=runtime_transport)
 
 
 def main():

--- a/tests/test_main_transport.py
+++ b/tests/test_main_transport.py
@@ -1,0 +1,69 @@
+import pytest
+
+import main
+
+
+class _DummyFastMCP:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.run_calls = []
+
+    def run(self, transport="stdio", mount_path=None):
+        self.run_calls.append({"transport": transport, "mount_path": mount_path})
+
+
+def _patch_runtime_dependencies(monkeypatch):
+    monkeypatch.setattr(main, "init_telemetry", lambda *a, **k: None)
+    monkeypatch.setattr(main, "get_token", lambda: object())
+    monkeypatch.setattr(main, "register_confirm_mode", lambda *a, **k: None)
+    monkeypatch.setattr(main, "register_tools", lambda *a, **k: None)
+    monkeypatch.setattr(main, "FastMCP", _DummyFastMCP)
+
+
+class TestResolveMcpTransport:
+    def test_precedence_cli_then_env_then_default(self, monkeypatch):
+        monkeypatch.delenv("BZM_MCP_TRANSPORT", raising=False)
+        assert main.resolve_mcp_transport("") == "stdio"
+
+        monkeypatch.setenv("BZM_MCP_TRANSPORT", "http")
+        assert main.resolve_mcp_transport("") == "http"
+
+        # CLI value must override environment fallback.
+        assert main.resolve_mcp_transport("docker") == "docker"
+
+    def test_invalid_transport_raises_clear_error(self, monkeypatch):
+        monkeypatch.delenv("BZM_MCP_TRANSPORT", raising=False)
+
+        with pytest.raises(ValueError, match="Invalid MCP transport"):
+            main.resolve_mcp_transport("banana")
+
+
+class TestBuildRuntimeHttp:
+    def test_http_runtime_uses_env_settings_and_stateful_http(self, monkeypatch):
+        _patch_runtime_dependencies(monkeypatch)
+        monkeypatch.setenv("FASTMCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("FASTMCP_PORT", "8012")
+        monkeypatch.setenv("FASTMCP_STREAMABLE_HTTP_PATH", "/custom-mcp")
+
+        mcp, runtime_transport = main.build_runtime(transport="http")
+
+        assert runtime_transport == "streamable-http"
+        assert isinstance(mcp, _DummyFastMCP)
+        assert mcp.kwargs["host"] == "0.0.0.0"
+        assert mcp.kwargs["port"] == 8012
+        assert mcp.kwargs["streamable_http_path"] == "/custom-mcp"
+        assert mcp.kwargs["stateless_http"] is False
+
+
+class TestBuildRuntimeTransportMapping:
+    def test_transport_mapping_keeps_docker_stdio_and_http_streamable(self, monkeypatch):
+        _patch_runtime_dependencies(monkeypatch)
+
+        _mcp_http, runtime_transport_http = main.build_runtime(transport="http")
+        _mcp_docker, runtime_transport_docker = main.build_runtime(transport="docker")
+        _mcp_stdio, runtime_transport_stdio = main.build_runtime(transport="stdio")
+
+        assert runtime_transport_http == "streamable-http"
+        assert runtime_transport_docker == "stdio"
+        assert runtime_transport_stdio == "stdio"


### PR DESCRIPTION
Adds explicit MCP transport selection (stdio, http, docker) with CLI/env precedence, introduces runtime transport mapping for Streamable HTTP support and preserves Docker stdio compatibility.