### PR TITLE
Add upper bound in mcp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "httpx[http2]>=0.28.1",
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.27.0,<2.0.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bzm-mcp"
-version = "1.3.0"
+version = "1.3.1"
 description = "BlazeMeter MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "bzm-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=5.3.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },


### PR DESCRIPTION
This pull request makes a minor update to the `pyproject.toml` file by restricting the `mcp[cli]` dependency to versions below 2.0.0 to prevent potential compatibility issues.

- Dependency version constraint:
  * Updated the `mcp[cli]` dependency requirement to `>=1.27.0,<2.0.0` in `pyproject.toml` to avoid unintended upgrades to incompatible major versions.