### PR TITLE
Upgrade Ubuntu image and enhance MCP transport configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,19 +35,19 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     
-    - name: Build binary (Linux in Ubuntu 25.10 container)
+    - name: Build binary (Linux in Ubuntu 26.04 container)
       if: matrix.name == 'linux'
       shell: bash
       run: |
-        # Docker container with Ubuntu 25.10 and build the binary inside it
+        # Docker container with Ubuntu 26.04 and build the binary inside it
         rm -rf dist/*
         docker run --rm \
           -v "$PWD:/workspace" \
           -w /workspace \
-          ubuntu:25.10 \
+          ubuntu:26.04 \
           bash -c "
             set -e
-            echo 'Setting up Ubuntu 25.10 build environment...'
+            echo 'Setting up Ubuntu 26.04 build environment...'
             
             apt-get update -y
             apt-get install -y --fix-missing curl python3 python3-pip python3-venv binutils

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ubuntu:25.10
+FROM ubuntu:26.04
 
 
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -209,6 +209,94 @@ When using custom CA certificate bundles, you must configure both:
 
 ---
 
+## OpenTelemetry
+
+BlazeMeter MCP reports traces and metrics for MCP tool calls using [OpenTelemetry](https://opentelemetry.io/). This gives you visibility into which tools are used, how long they take, and when errors occur.
+
+Telemetry is enabled by default. You do not need to configure anything unless you want to change where data is sent or turn it off.
+
+### Default behavior
+
+By default, telemetry is exported over gRPC to:
+
+`https://grpc.public.prd.shared.perforce.com`
+
+The service is identified as `bzm-mcp` with the current release version. If telemetry fails to start or export, the MCP server continues to work as usual.
+
+### Turn off telemetry
+
+Add `OTEL_SDK_DISABLED=true` to your MCP client environment:
+
+```json
+"env": {
+  "OTEL_SDK_DISABLED": "true"
+}
+```
+
+For Docker, pass it with `-e`:
+
+```json
+"-e",
+"OTEL_SDK_DISABLED=true"
+```
+
+You can also pass `--no-telemetry` on the command line (binary or `uvx` install):
+
+```json
+"args": ["--mcp", "--no-telemetry"]
+```
+
+### Send data to your own collector
+
+Use these environment variables to point at a different OpenTelemetry collector (for example, a local one during development):
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP collector URL | `https://grpc.public.prd.shared.perforce.com` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc`, `http/protobuf`, or `http/json` | `grpc` |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Comma-separated `key=value` headers for the collector | _(none)_ |
+
+gRPC example (typical local collector on port 4317):
+
+```json
+"env": {
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4317",
+  "OTEL_EXPORTER_OTLP_PROTOCOL": "grpc"
+}
+```
+
+HTTP example (typical local collector on port 4318):
+
+```json
+"env": {
+  "OTEL_EXPORTER_OTLP_ENDPOINT": "http://localhost:4318",
+  "OTEL_EXPORTER_OTLP_PROTOCOL": "http/protobuf"
+}
+```
+
+When running the binary directly, you can override the endpoint and headers with CLI flags instead of environment variables:
+
+```json
+"args": [
+  "--mcp",
+  "--otel-endpoint", "http://localhost:4317",
+  "--otel-headers", "Authorization=Bearer token"
+]
+```
+
+### What gets reported
+
+Each MCP tool call creates:
+
+- **Traces** — one span per call with the tool name, action, MCP client name and version, session ID, and error type when applicable.
+- **Metrics** — `mcp.tool.calls` (count) and `mcp.tool.duration` (seconds), broken down by tool and action.
+
+Security tokens and other credentials are not included in telemetry data.
+
+If your MCP client sends `traceparent` or `tracestate` in the request metadata, BlazeMeter MCP links its spans to that parent trace.
+
+---
+
 ## License
 
 This project is licensed under the Apache License, Version 2.0. Please refer to [LICENSE](./LICENSE) for the full terms.

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from tools.utils import ConfirmMode, register_confirm_mode
 BLAZEMETER_API_KEY_FILE_PATH = os.getenv('BLAZEMETER_API_KEY')
 
 LOG_LEVELS = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+MCP_TRANSPORTS = ("stdio", "http", "docker")
 
 # Canonical server label for printed JSON and clients that accept arbitrary string ids.
 MCP_SERVER_DISPLAY_NAME = "BlazeMeter MCP"
@@ -373,9 +374,50 @@ def get_token():
     return token
 
 
-def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE):
+def resolve_mcp_transport(raw_cli_transport: str) -> str:
+    """
+    Resolve transport with precedence: CLI > BZM_MCP_TRANSPORT > stdio.
+
+    `raw_cli_transport` comes from argparse `--mcp`:
+    - empty string means `--mcp` was provided without an explicit value
+    - non-empty string means an explicit CLI transport was provided
+    """
+    raw_cli_transport = raw_cli_transport.strip()
+
+    if raw_cli_transport:
+        candidate = raw_cli_transport
+        source = "CLI --mcp"
+    else:
+        candidate = os.getenv("BZM_MCP_TRANSPORT", "").strip()
+        source = "BZM_MCP_TRANSPORT"
+
+    if not candidate:
+        return "stdio"
+
+    normalized = candidate.lower()
+    if normalized not in MCP_TRANSPORTS:
+        allowed = ", ".join(MCP_TRANSPORTS)
+        raise ValueError(
+            f"Invalid MCP transport '{candidate}' from {source}. "
+            f"Valid values: {allowed}."
+        )
+    return normalized
+
+
+def build_runtime(
+        log_level: str = "CRITICAL",
+        confirm_mode: ConfirmMode = ConfirmMode.DELETE,
+        transport: str = "stdio",
+) -> tuple[FastMCP, str]:
     init_telemetry("bzm-mcp", __version__)
     token = get_token()
+    host = "127.0.0.1"
+    port = 8000
+    streamable_http_path = "/mcp"
+    if transport == "http":
+        host = os.getenv("FASTMCP_HOST", "127.0.0.1").strip() or "127.0.0.1"
+        port = int(os.getenv("FASTMCP_PORT", "8000").strip() or "8000")
+        streamable_http_path = os.getenv("FASTMCP_STREAMABLE_HTTP_PATH", "/mcp").strip() or "/mcp"
     instructions = """
 # BlazeMeter MCP Server
 A comprehensive integration tool that provides AI assistants with full programmatic access to BlazeMeter's cloud-based performance testing platform. Enables automated management of complete load testing workflows from creation to execution and reporting. Transforms enterprise-grade testing capabilities into an AI-accessible service for intelligent automation of complex performance testing scenarios.
@@ -431,10 +473,28 @@ A comprehensive integration tool that provides AI assistants with full programma
 - **Proactive Troubleshooting**: Use the skills for troubleshooting any detected issues.
 - **Failure criteria**: The same field names appear when you read a test and when you configure failure criteria (`failure_criteria` on the test); the server handles BlazeMeter’s REST format internally. Use `failure_criteria_meta` for field definitions and KPI/condition catalogs. When describing criteria to the user, use `meta.general_labels`, `meta.rule_field_labels`, `meta.kpi_labels`, and `meta.condition_labels`; use raw metric and operator ids only inside tool calls. Use `configure_failure_criteria` only after user confirmation; it replaces all rules unless you merge from a prior read.
     """
-    mcp = FastMCP("blazemeter-mcp", instructions=instructions, log_level=cast(LOG_LEVELS, log_level))
+    mcp = FastMCP(
+        "blazemeter-mcp",
+        instructions=instructions,
+        log_level=cast(LOG_LEVELS, log_level),
+        host=host,
+        port=port,
+        streamable_http_path=streamable_http_path,
+        stateless_http=False,
+    )
     register_confirm_mode(confirm_mode)
     register_tools(mcp, token)
-    mcp.run(transport="stdio")
+    runtime_transport = "streamable-http" if transport == "http" else "stdio"
+    return mcp, runtime_transport
+
+
+def run(log_level: str = "CRITICAL", confirm_mode: ConfirmMode = ConfirmMode.DELETE, transport: str = "stdio"):
+    mcp, runtime_transport = build_runtime(
+        log_level=log_level,
+        confirm_mode=confirm_mode,
+        transport=transport,
+    )
+    mcp.run(transport=runtime_transport)
 
 
 def main():
@@ -451,8 +511,13 @@ def main():
 
     parser.add_argument(
         "--mcp",
-        action="store_true",
-        help="Execute MCP Server"
+        nargs="?",
+        const="",
+        metavar="TRANSPORT",
+        help=(
+            "Execute MCP Server. Optional TRANSPORT values: stdio, http, docker.\n"
+            "Resolution precedence: CLI > BZM_MCP_TRANSPORT > stdio."
+        ),
     )
 
     parser.add_argument(
@@ -505,9 +570,17 @@ def main():
     if args.otel_headers:
         os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = ",".join(args.otel_headers)
 
-    if args.mcp:
-        init_logging(args.log_level)
-        run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm])
+    if args.mcp is not None:
+        try:
+            transport = resolve_mcp_transport(args.mcp)
+            if transport == "docker":
+                os.environ["MCP_DOCKER"] = "true"
+            elif transport == "http":
+                os.environ["MCP_DOCKER"] = "false"
+            init_logging(args.log_level)
+            run(log_level=args.log_level.upper(), confirm_mode=ConfirmMode[args.confirm], transport=transport)
+        except ValueError as e:
+            parser.error(str(e))
     else:
 
         logo_ascii = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "httpx[http2]>=0.28.1",
-    "mcp[cli]>=1.27.0",
+    "mcp[cli]>=1.27.0,<2.0.0",
     "opentelemetry-api>=1.20.0",
     "opentelemetry-sdk>=1.20.0",
     "opentelemetry-exporter-otlp>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bzm-mcp"
-version = "1.3.0"
+version = "1.3.1"
 description = "BlazeMeter MCP"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_main_transport.py
+++ b/tests/test_main_transport.py
@@ -1,0 +1,69 @@
+import pytest
+
+import main
+
+
+class _DummyFastMCP:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.run_calls = []
+
+    def run(self, transport="stdio", mount_path=None):
+        self.run_calls.append({"transport": transport, "mount_path": mount_path})
+
+
+def _patch_runtime_dependencies(monkeypatch):
+    monkeypatch.setattr(main, "init_telemetry", lambda *a, **k: None)
+    monkeypatch.setattr(main, "get_token", lambda: object())
+    monkeypatch.setattr(main, "register_confirm_mode", lambda *a, **k: None)
+    monkeypatch.setattr(main, "register_tools", lambda *a, **k: None)
+    monkeypatch.setattr(main, "FastMCP", _DummyFastMCP)
+
+
+class TestResolveMcpTransport:
+    def test_precedence_cli_then_env_then_default(self, monkeypatch):
+        monkeypatch.delenv("BZM_MCP_TRANSPORT", raising=False)
+        assert main.resolve_mcp_transport("") == "stdio"
+
+        monkeypatch.setenv("BZM_MCP_TRANSPORT", "http")
+        assert main.resolve_mcp_transport("") == "http"
+
+        # CLI value must override environment fallback.
+        assert main.resolve_mcp_transport("docker") == "docker"
+
+    def test_invalid_transport_raises_clear_error(self, monkeypatch):
+        monkeypatch.delenv("BZM_MCP_TRANSPORT", raising=False)
+
+        with pytest.raises(ValueError, match="Invalid MCP transport"):
+            main.resolve_mcp_transport("banana")
+
+
+class TestBuildRuntimeHttp:
+    def test_http_runtime_uses_env_settings_and_stateful_http(self, monkeypatch):
+        _patch_runtime_dependencies(monkeypatch)
+        monkeypatch.setenv("FASTMCP_HOST", "0.0.0.0")
+        monkeypatch.setenv("FASTMCP_PORT", "8012")
+        monkeypatch.setenv("FASTMCP_STREAMABLE_HTTP_PATH", "/custom-mcp")
+
+        mcp, runtime_transport = main.build_runtime(transport="http")
+
+        assert runtime_transport == "streamable-http"
+        assert isinstance(mcp, _DummyFastMCP)
+        assert mcp.kwargs["host"] == "0.0.0.0"
+        assert mcp.kwargs["port"] == 8012
+        assert mcp.kwargs["streamable_http_path"] == "/custom-mcp"
+        assert mcp.kwargs["stateless_http"] is False
+
+
+class TestBuildRuntimeTransportMapping:
+    def test_transport_mapping_keeps_docker_stdio_and_http_streamable(self, monkeypatch):
+        _patch_runtime_dependencies(monkeypatch)
+
+        _mcp_http, runtime_transport_http = main.build_runtime(transport="http")
+        _mcp_docker, runtime_transport_docker = main.build_runtime(transport="docker")
+        _mcp_stdio, runtime_transport_stdio = main.build_runtime(transport="stdio")
+
+        assert runtime_transport_http == "streamable-http"
+        assert runtime_transport_docker == "stdio"
+        assert runtime_transport_stdio == "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "bzm-mcp"
-version = "1.2.0"
+version = "1.3.0"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },
@@ -84,7 +84,7 @@ dev = [
 requires-dist = [
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
     { name = "lxml", specifier = ">=5.3.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.27.0,<2.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.20.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.20.0" },
     { name = "opentelemetry-sdk", specifier = ">=1.20.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -58,7 +58,7 @@ wheels = [
 
 [[package]]
 name = "bzm-mcp"
-version = "1.3.0"
+version = "1.3.1"
 source = { virtual = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
This pull request introduces improved configurability for MCP server transport selection, adds comprehensive OpenTelemetry documentation, and ensures compatibility with the new Ubuntu 26.04 base image. It also includes version pinning for dependencies and adds tests for the new transport resolution logic.

**Transport selection and runtime configuration:**

* Refactored MCP server startup to allow explicit selection of transport (`stdio`, `http`, or `docker`) via CLI, environment variable, or default, with clear precedence and validation. The new `resolve_mcp_transport` and `build_runtime` functions encapsulate this logic, and the CLI now supports `--mcp [TRANSPORT]` 
* Added tests in `tests/test_main_transport.py` to verify transport precedence, error handling, and runtime configuration for all supported transports.

**OpenTelemetry documentation:**

* Added a new section to `README.md` detailing default telemetry behavior, how to disable telemetry, how to configure custom collectors, and what data is reported, improving user visibility and control over telemetry.

**Dependency and platform updates:**

* Updated the Docker base image and GitHub Actions workflow to use Ubuntu 26.04 instead of 25.10 for consistency and future-proofing.
* Pinned the `mcp` dependency to `<2.0.0` and bumped the project version to `1.3.1` in `pyproject.toml` for compatibility and release tracking.