### PR TITLE
Mob 50447 per session elicitation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,44 +110,6 @@ After installing, set `BLAZEMETER_API_KEY` to your `api-key.json` path in your c
 
 ---
 
-**Hosted HTTP (streamable-http)**
-
-Connect to the shared hosted server with Bearer auth. Production URL: `https://mcp.blazemeter.com/mcp`
-
-To run your own shared server locally that authenticates each client via `Authorization: Bearer`:
-
-```bash
-uv run python main.py --mcp http
-```
-
-Configure the MCP client with the server URL and these headers:
-
-- `Authorization`: BlazeMeter credentials as Bearer (`id:secret` or base64 of `id:secret`)
-- `Confirmation-Mode`: confirmation policy (`DELETE`, `CUD`, or `DISABLE`)
-
-```json
-{
-  "mcpServers": {
-    "BlazeMeter MCP": {
-      "url": "https://mcp.blazemeter.com/mcp",
-      "headers": {
-        "Authorization": "Bearer <apiKeyId>:<apiKeySecret>",
-        "Confirmation-Mode": "DELETE"
-      }
-    }
-  }
-}
-```
-
-> [!NOTE]  
-> Over HTTP, credentials are resolved per request from the `Authorization` header. Invalid or missing Bearer credentials return `401` before any tool runs. Well-formed but wrong API keys fail later inside BlazeMeter API calls (same as stdio). Stdio transport uses `api-key.json` / env / Docker secrets.
->
-> `Confirmation-Mode` defaults to `DELETE` when omitted. For streamable HTTP sessions, the server persists the selected mode per MCP session id, so if the client sends `Confirmation-Mode` once for a session, subsequent requests in that same session can reuse it.
->
-> For local/operator HTTP setup, env vars, auth behavior, and MVP limits (including `upload_assets`), see [docs/hosted-http.md](docs/hosted-http.md).
-
----
-
 **Docker MCP Client Configuration**
 
 1. **Prerequisites:** [Docker]([https://www.docker.com/products/docker-desktop/](https://www.docker.com/products/docker-desktop/))

--- a/README.md
+++ b/README.md
@@ -114,13 +114,25 @@ After installing, set `BLAZEMETER_API_KEY` to your `api-key.json` path in your c
 
 Connect to the shared hosted server with Bearer auth. Production URL: `https://mcp.blazemeter.com/mcp`
 
+To run your own shared server locally that authenticates each client via `Authorization: Bearer`:
+
+```bash
+uv run python main.py --mcp http
+```
+
+Configure the MCP client with the server URL and these headers:
+
+- `Authorization`: BlazeMeter credentials as Bearer (`id:secret` or base64 of `id:secret`)
+- `Confirmation-Mode`: confirmation policy (`DELETE`, `CUD`, or `DISABLE`)
+
 ```json
 {
   "mcpServers": {
     "BlazeMeter MCP": {
       "url": "https://mcp.blazemeter.com/mcp",
       "headers": {
-        "Authorization": "Bearer <apiKeyId>:<apiKeySecret>"
+        "Authorization": "Bearer <apiKeyId>:<apiKeySecret>",
+        "Confirmation-Mode": "DELETE"
       }
     }
   }
@@ -128,6 +140,10 @@ Connect to the shared hosted server with Bearer auth. Production URL: `https://m
 ```
 
 > [!NOTE]  
+> Over HTTP, credentials are resolved per request from the `Authorization` header. Invalid or missing Bearer credentials return `401` before any tool runs. Well-formed but wrong API keys fail later inside BlazeMeter API calls (same as stdio). Stdio transport uses `api-key.json` / env / Docker secrets.
+>
+> `Confirmation-Mode` defaults to `DELETE` when omitted. For streamable HTTP sessions, the server persists the selected mode per MCP session id, so if the client sends `Confirmation-Mode` once for a session, subsequent requests in that same session can reuse it.
+>
 > For local/operator HTTP setup, env vars, auth behavior, and MVP limits (including `upload_assets`), see [docs/hosted-http.md](docs/hosted-http.md).
 
 ---

--- a/config/auth.py
+++ b/config/auth.py
@@ -27,9 +27,6 @@ from config.token import BzmToken, BzmTokenError
 BZM_TOKEN_STATE_ATTR = "token"
 BZM_USER_CONFIG_STATE_ATTR = "user_config"
 BZM_CONFIRMATION_MODE_HEADER = "confirmation-mode"
-BZM_SESSION_ID_HEADER = "mcp-session-id"
-
-_SESSION_CONFIRMATION_MODE: dict[tuple[str, str], str] = {}
 
 
 def _normalize_confirmation_mode(raw_value: Optional[str]) -> str:
@@ -40,14 +37,6 @@ def _normalize_confirmation_mode(raw_value: Optional[str]) -> str:
         return value
     return "DELETE"
 
-
-def _session_store_key(token: BzmToken, session_id: str) -> tuple[str, str]:
-    return token.id, session_id
-
-
-def clear_confirmation_mode_session_store() -> None:
-    """Test/helper hook to reset process-local session confirmation cache."""
-    _SESSION_CONFIRMATION_MODE.clear()
 
 # Unauthenticated probe paths for orchestrators / load balancers.
 HEALTH_PATHS = frozenset({"/health", "/healthz"})
@@ -142,17 +131,9 @@ class BearerAuthMiddleware:
             return
 
         setattr(request.state, BZM_TOKEN_STATE_ATTR, token)
-        session_id = request.headers.get(BZM_SESSION_ID_HEADER, "").strip()
         raw_confirmation_mode = request.headers.get(BZM_CONFIRMATION_MODE_HEADER)
         if raw_confirmation_mode is not None and raw_confirmation_mode.strip():
             confirmation_mode = _normalize_confirmation_mode(raw_confirmation_mode)
-            if session_id:
-                _SESSION_CONFIRMATION_MODE[_session_store_key(token, session_id)] = confirmation_mode
-        elif session_id:
-            confirmation_mode = _SESSION_CONFIRMATION_MODE.get(
-                _session_store_key(token, session_id),
-                "DELETE",
-            )
         else:
             confirmation_mode = "DELETE"
         setattr(

--- a/config/auth.py
+++ b/config/auth.py
@@ -27,6 +27,27 @@ from config.token import BzmToken, BzmTokenError
 BZM_TOKEN_STATE_ATTR = "token"
 BZM_USER_CONFIG_STATE_ATTR = "user_config"
 BZM_CONFIRMATION_MODE_HEADER = "confirmation-mode"
+BZM_SESSION_ID_HEADER = "mcp-session-id"
+
+_SESSION_CONFIRMATION_MODE: dict[tuple[str, str], str] = {}
+
+
+def _normalize_confirmation_mode(raw_value: Optional[str]) -> str:
+    value = (raw_value or "").strip().upper()
+    if value == "NONE":
+        return "DISABLE"
+    if value in ("DELETE", "CUD", "DISABLE"):
+        return value
+    return "DELETE"
+
+
+def _session_store_key(token: BzmToken, session_id: str) -> tuple[str, str]:
+    return token.id, session_id
+
+
+def clear_confirmation_mode_session_store() -> None:
+    """Test/helper hook to reset process-local session confirmation cache."""
+    _SESSION_CONFIRMATION_MODE.clear()
 
 # Unauthenticated probe paths for orchestrators / load balancers.
 HEALTH_PATHS = frozenset({"/health", "/healthz"})
@@ -121,7 +142,19 @@ class BearerAuthMiddleware:
             return
 
         setattr(request.state, BZM_TOKEN_STATE_ATTR, token)
-        confirmation_mode = request.headers.get(BZM_CONFIRMATION_MODE_HEADER, "DELETE")
+        session_id = request.headers.get(BZM_SESSION_ID_HEADER, "").strip()
+        raw_confirmation_mode = request.headers.get(BZM_CONFIRMATION_MODE_HEADER)
+        if raw_confirmation_mode is not None and raw_confirmation_mode.strip():
+            confirmation_mode = _normalize_confirmation_mode(raw_confirmation_mode)
+            if session_id:
+                _SESSION_CONFIRMATION_MODE[_session_store_key(token, session_id)] = confirmation_mode
+        elif session_id:
+            confirmation_mode = _SESSION_CONFIRMATION_MODE.get(
+                _session_store_key(token, session_id),
+                "DELETE",
+            )
+        else:
+            confirmation_mode = "DELETE"
         setattr(
             request.state,
             BZM_USER_CONFIG_STATE_ATTR,

--- a/config/auth.py
+++ b/config/auth.py
@@ -31,8 +31,6 @@ BZM_CONFIRMATION_MODE_HEADER = "confirmation-mode"
 
 def _normalize_confirmation_mode(raw_value: Optional[str]) -> str:
     value = (raw_value or "").strip().upper()
-    if value == "NONE":
-        return "DISABLE"
     if value in ("DELETE", "CUD", "DISABLE"):
         return value
     return "DELETE"

--- a/config/auth.py
+++ b/config/auth.py
@@ -25,6 +25,8 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from config.token import BzmToken, BzmTokenError
 
 BZM_TOKEN_STATE_ATTR = "token"
+BZM_USER_CONFIG_STATE_ATTR = "user_config"
+BZM_CONFIRMATION_MODE_HEADER = "confirmation-mode"
 
 # Unauthenticated probe paths for orchestrators / load balancers.
 HEALTH_PATHS = frozenset({"/health", "/healthz"})
@@ -119,6 +121,12 @@ class BearerAuthMiddleware:
             return
 
         setattr(request.state, BZM_TOKEN_STATE_ATTR, token)
+        confirmation_mode = request.headers.get(BZM_CONFIRMATION_MODE_HEADER, "DELETE")
+        setattr(
+            request.state,
+            BZM_USER_CONFIG_STATE_ATTR,
+            {"confirmation_mode": confirmation_mode},
+        )
         await self.app(scope, receive, send)
 
 

--- a/config/context_resolution.py
+++ b/config/context_resolution.py
@@ -1,0 +1,50 @@
+"""
+Copyright 2025 Perforce Software, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+from typing import Any
+
+from config.auth import BZM_TOKEN_STATE_ATTR, BZM_USER_CONFIG_STATE_ATTR
+
+
+def get_request_context(ctx: Any) -> Any:
+    return getattr(ctx, "request_context", None)
+
+
+def get_request_state(ctx: Any) -> Any:
+    request_context = get_request_context(ctx)
+    request = getattr(request_context, "request", None)
+    return getattr(request, "state", None)
+
+
+def resolve_ctx_user_config(ctx: Any) -> dict[str, Any]:
+    request_context = get_request_context(ctx)
+    request_state = get_request_state(ctx)
+
+    request_context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
+    if isinstance(request_context_config, dict):
+        return request_context_config
+
+    request_state_config = getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
+    if isinstance(request_state_config, dict):
+        return request_state_config
+
+    return {}
+
+
+def resolve_ctx_token(ctx: Any) -> Any:
+    user_config = resolve_ctx_user_config(ctx)
+    request_state = get_request_state(ctx)
+    request_state_token = getattr(request_state, BZM_TOKEN_STATE_ATTR, None)
+    return user_config.get("token") or request_state_token

--- a/config/runtime.py
+++ b/config/runtime.py
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 from dataclasses import dataclass
-from typing import Literal, Optional
 import os
+from typing import Any, Literal, Optional
 
 from config.auth import AuthPort, HttpAuthProvider, StdioAuthProvider
 from config.file_access import FileAccessPort, build_file_access
@@ -27,6 +27,7 @@ from config.storage import (
     SessionStoragePort,
 )
 from config.token import BzmToken
+from tools.utils import ConfirmMode
 
 Transport = Literal["stdio", "streamable-http"]
 
@@ -40,11 +41,13 @@ class AppRuntime:
     storage: SessionStoragePort
     file_access: FileAccessPort
     scope_resolver: SessionScopeResolverPort
+    user_config: dict[str, Any]
 
 
 def build_runtime(
         transport: Transport,
         startup_token: Optional[BzmToken] = None,
+        startup_confirmation_mode: ConfirmMode = ConfirmMode.DELETE,
 ) -> AppRuntime:
     """
     Compose auth, file access, and session storage for the selected transport.
@@ -53,12 +56,17 @@ def build_runtime(
     - streamable-http: request-scoped auth and storage API-backed partitions.
     """
     if transport == "stdio":
+        stdio_user_config = {
+            "startup_token": startup_token,
+            "confirmation_mode": startup_confirmation_mode.name,
+        }
         return AppRuntime(
             transport=transport,
             auth=StdioAuthProvider(startup_token),
             storage=InMemorySessionStorageProvider(),
             file_access=build_file_access(transport),
             scope_resolver=DefaultSessionScopeResolver(),
+            user_config=stdio_user_config,
         )
 
     if transport == "streamable-http":
@@ -77,6 +85,7 @@ def build_runtime(
             storage=storage,
             file_access=build_file_access(transport),
             scope_resolver=DefaultSessionScopeResolver(),
+            user_config={},
         )
 
     raise ValueError(f"Unknown transport: {transport}")

--- a/config/runtime.py
+++ b/config/runtime.py
@@ -48,6 +48,19 @@ class AppRuntime:
     scope_resolver: SessionScopeResolverPort
     user_config: dict[str, Any]
 
+    def resolve_user_config(self, ctx: Any) -> dict[str, Any]:
+        user_config = dict(self.user_config)
+        user_config.update(_read_ctx_user_config(ctx))
+        token = self.auth.get_token(ctx)
+        if token is not None:
+            user_config["token"] = token
+        return user_config
+
+    def configure_context(self, ctx: Any) -> dict[str, Any]:
+        user_config = self.resolve_user_config(ctx)
+        _hydrate_ctx_user_config(ctx, user_config)
+        return user_config
+
 
 def _read_ctx_user_config(ctx: Any) -> dict[str, Any]:
     if ctx is None:
@@ -82,17 +95,6 @@ def _hydrate_ctx_user_config(ctx: Any, user_config: dict[str, Any]) -> None:
     for target in (request_context, request_state):
         if target is not None:
             setattr(target, BZM_USER_CONFIG_STATE_ATTR, dict(config_copy))
-
-
-def build_user_config(runtime: AppRuntime, ctx) -> dict[str, Any]:
-    user_config = dict(runtime.user_config)
-    user_config.update(_read_ctx_user_config(ctx))
-    token = runtime.auth.get_token(ctx)
-    if token is not None:
-        user_config["token"] = token
-
-    _hydrate_ctx_user_config(ctx, user_config)
-    return user_config
 
 
 def build_runtime(

--- a/config/runtime.py
+++ b/config/runtime.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass
 import os
 from typing import Any, Literal, Optional
 
-from config.auth import AuthPort, HttpAuthProvider, StdioAuthProvider
+from config.auth import (
+    AuthPort,
+    BZM_USER_CONFIG_STATE_ATTR,
+    HttpAuthProvider,
+    StdioAuthProvider,
+)
 from config.file_access import FileAccessPort, build_file_access
 from config.storage import (
     DefaultSessionScopeResolver,
@@ -44,11 +49,49 @@ class AppRuntime:
     user_config: dict[str, Any]
 
 
+def _read_ctx_user_config(ctx: Any) -> dict[str, Any]:
+    if ctx is None:
+        return {}
+
+    user_config: dict[str, Any] = {}
+    request_context = getattr(ctx, "request_context", None)
+    request = getattr(request_context, "request", None)
+    request_state = getattr(request, "state", None)
+
+    for target, attr_name in (
+        (ctx, "user_config"),
+        (request_context, BZM_USER_CONFIG_STATE_ATTR),
+        (request_state, BZM_USER_CONFIG_STATE_ATTR),
+    ):
+        request_config = getattr(target, attr_name, None)
+        if isinstance(request_config, dict):
+            user_config.update(request_config)
+
+    return user_config
+
+
+def _hydrate_ctx_user_config(ctx: Any, user_config: dict[str, Any]) -> None:
+    if ctx is None:
+        return
+
+    config_copy = dict(user_config)
+    request_context = getattr(ctx, "request_context", None)
+    request = getattr(request_context, "request", None)
+    request_state = getattr(request, "state", None)
+
+    for target in (request_context, request_state):
+        if target is not None:
+            setattr(target, BZM_USER_CONFIG_STATE_ATTR, dict(config_copy))
+
+
 def build_user_config(runtime: AppRuntime, ctx) -> dict[str, Any]:
     user_config = dict(runtime.user_config)
+    user_config.update(_read_ctx_user_config(ctx))
     token = runtime.auth.get_token(ctx)
     if token is not None:
         user_config["token"] = token
+
+    _hydrate_ctx_user_config(ctx, user_config)
     return user_config
 
 

--- a/config/runtime.py
+++ b/config/runtime.py
@@ -44,6 +44,14 @@ class AppRuntime:
     user_config: dict[str, Any]
 
 
+def build_user_config(runtime: AppRuntime, ctx) -> dict[str, Any]:
+    user_config = dict(runtime.user_config)
+    token = runtime.auth.get_token(ctx)
+    if token is not None:
+        user_config["token"] = token
+    return user_config
+
+
 def build_runtime(
         transport: Transport,
         startup_token: Optional[BzmToken] = None,
@@ -58,6 +66,7 @@ def build_runtime(
     if transport == "stdio":
         stdio_user_config = {
             "startup_token": startup_token,
+            "token": startup_token,
             "confirmation_mode": startup_confirmation_mode.name,
         }
         return AppRuntime(

--- a/docs/hosted-http.md
+++ b/docs/hosted-http.md
@@ -16,7 +16,8 @@ Configure the MCP client with that URL and your BlazeMeter API key as Bearer cre
     "BlazeMeter MCP": {
       "url": "https://mcp.blazemeter.com/mcp",
       "headers": {
-        "Authorization": "Bearer <apiKeyId>:<apiKeySecret>"
+        "Authorization": "Bearer <apiKeyId>:<apiKeySecret>",
+        "confirmation-mode": "DELETE"
       }
     }
   }
@@ -31,6 +32,12 @@ For a locally run server, use `"url": "http://localhost:8000/mcp"` instead.
 - Invalid or missing Bearer credentials return `401` before any tool runs.
 - Well-formed but wrong API keys fail later inside BlazeMeter API calls (same as stdio).
 - Stdio / local Docker transport uses `api-key.json` / env / Docker secrets instead of Bearer auth.
+
+### Confirmation mode header
+
+- Optional header: `confirmation-mode`
+- Allowed values: `DELETE`, `CUD`, `DISABLE`
+- If omitted, empty, or invalid, the server falls back to `DELETE`.
 
 ## Local / operator run
 

--- a/docs/hosted-http.md
+++ b/docs/hosted-http.md
@@ -37,7 +37,7 @@ For a locally run server, use `"url": "http://localhost:8000/mcp"` instead.
 
 - Optional header: `confirmation-mode`
 - Allowed values: `DELETE`, `CUD`, `DISABLE`
-- If omitted, empty, or invalid, the server falls back to `DELETE`.
+- If omitted, empty, or invalid, the session falls back to `DELETE`.
 
 ## Local / operator run
 

--- a/main.py
+++ b/main.py
@@ -35,7 +35,7 @@ from config.token import BzmToken, BzmTokenError
 from config.version import __version__, __executable__, __bundle__
 from server import register_tools
 from telemetry import init_telemetry
-from tools.utils import ConfirmMode, register_confirm_mode
+from tools.utils import ConfirmMode
 
 BLAZEMETER_API_KEY_FILE_PATH = os.getenv('BLAZEMETER_API_KEY')
 
@@ -442,6 +442,7 @@ def build_mcp_server(
     app_runtime = build_runtime(
         wire_transport,
         startup_token=get_token() if wire_transport == "stdio" else None,
+        startup_confirmation_mode=confirm_mode,
     )
     instructions = """
 # BlazeMeter MCP Server
@@ -507,7 +508,6 @@ A comprehensive integration tool that provides AI assistants with full programma
         streamable_http_path=streamable_http_path,
         stateless_http=False,
     )
-    register_confirm_mode(confirm_mode)
     register_tools(mcp, app_runtime)
     return mcp, wire_transport
 

--- a/models/manager.py
+++ b/models/manager.py
@@ -13,15 +13,29 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Any, Optional
-
 from mcp.server.fastmcp import Context
+
+from config.auth import BZM_TOKEN_STATE_ATTR, BZM_USER_CONFIG_STATE_ATTR
 
 class Manager:
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
         self.ctx = ctx
-        self.user_config = dict(user_config or {})
+        # depending on the transport, I can get the token from the request context or request state inside ctx
+        request_context = getattr(ctx, "request_context", None)
+        request_state = getattr(getattr(request_context, "request", None), "state", None)
+
+        request_context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
+        request_state_config = getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
+
+        if isinstance(request_context_config, dict):
+            user_config = request_context_config
+        elif isinstance(request_state_config, dict):
+            user_config = request_state_config
+        else:
+            user_config = {}
+
+        request_state_token = getattr(request_state, BZM_TOKEN_STATE_ATTR, None)
+        self.token = user_config.get("token") or request_state_token

--- a/models/manager.py
+++ b/models/manager.py
@@ -17,16 +17,11 @@ from typing import Any, Optional
 
 from mcp.server.fastmcp import Context
 
-from config.token import BzmToken
-
-
 class Manager:
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        self.token = token
         self.ctx = ctx
-        self.user_config = user_config or {}
+        self.user_config = dict(user_config or {})

--- a/models/manager.py
+++ b/models/manager.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Optional
+from typing import Any, Optional
 
 from mcp.server.fastmcp import Context
 
@@ -21,6 +21,12 @@ from config.token import BzmToken
 
 
 class Manager:
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
         self.token = token
         self.ctx = ctx
+        self.user_config = user_config or {}

--- a/models/manager.py
+++ b/models/manager.py
@@ -15,7 +15,7 @@ limitations under the License.
 """
 from mcp.server.fastmcp import Context
 
-from config.auth import BZM_TOKEN_STATE_ATTR, BZM_USER_CONFIG_STATE_ATTR
+from config.context_resolution import resolve_ctx_token
 
 class Manager:
     def __init__(
@@ -23,19 +23,4 @@ class Manager:
         ctx: Context,
     ):
         self.ctx = ctx
-        # depending on the transport, I can get the token from the request context or request state inside ctx
-        request_context = getattr(ctx, "request_context", None)
-        request_state = getattr(getattr(request_context, "request", None), "state", None)
-
-        request_context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
-        request_state_config = getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
-
-        if isinstance(request_context_config, dict):
-            user_config = request_context_config
-        elif isinstance(request_state_config, dict):
-            user_config = request_state_config
-        else:
-            user_config = {}
-
-        request_state_token = getattr(request_state, BZM_TOKEN_STATE_ATTR, None)
-        self.token = user_config.get("token") or request_state_token
+        self.token = resolve_ctx_token(ctx)

--- a/tests/test_confirmation_behavior.py
+++ b/tests/test_confirmation_behavior.py
@@ -18,12 +18,13 @@ import asyncio
 from types import SimpleNamespace
 
 from models.result import BaseResult
-from tools.utils import ConfirmMode, Operations, register_confirm_mode, require_confirmation
+from tools.utils import Operations, require_confirmation
 
 
 class _ManagerWithConfirmation:
-    def __init__(self, ctx):
+    def __init__(self, ctx, confirmation_mode: str = "DELETE"):
         self.ctx = ctx
+        self.user_config = {"confirmation_mode": confirmation_mode}
 
     @require_confirmation(operation=Operations.CREATE)
     async def do_create(self):
@@ -47,8 +48,7 @@ class _RejectContext:
 
 class TestConfirmationBehavior:
     def test_blocks_when_confirmation_required_and_elicit_unsupported(self):
-        register_confirm_mode(ConfirmMode.CUD)
-        manager = _ManagerWithConfirmation(_NoElicitContext())
+        manager = _ManagerWithConfirmation(_NoElicitContext(), confirmation_mode="CUD")
 
         result = asyncio.run(manager.do_create())
 
@@ -57,8 +57,7 @@ class TestConfirmationBehavior:
         assert result.result is None
 
     def test_allows_when_confirmation_required_and_user_accepts(self):
-        register_confirm_mode(ConfirmMode.CUD)
-        manager = _ManagerWithConfirmation(_AcceptContext())
+        manager = _ManagerWithConfirmation(_AcceptContext(), confirmation_mode="CUD")
 
         result = asyncio.run(manager.do_create())
 
@@ -66,8 +65,7 @@ class TestConfirmationBehavior:
         assert result.result == ["created"]
 
     def test_returns_cancelled_when_confirmation_required_and_user_declines(self):
-        register_confirm_mode(ConfirmMode.CUD)
-        manager = _ManagerWithConfirmation(_RejectContext())
+        manager = _ManagerWithConfirmation(_RejectContext(), confirmation_mode="CUD")
 
         result = asyncio.run(manager.do_create())
 
@@ -75,8 +73,7 @@ class TestConfirmationBehavior:
         assert result.result == ["Action manually cancelled by the user."]
 
     def test_allows_when_confirmation_not_required_even_without_elicit(self):
-        register_confirm_mode(ConfirmMode.DISABLE)
-        manager = _ManagerWithConfirmation(_NoElicitContext())
+        manager = _ManagerWithConfirmation(_NoElicitContext(), confirmation_mode="DISABLE")
 
         result = asyncio.run(manager.do_create())
 

--- a/tests/test_confirmation_behavior.py
+++ b/tests/test_confirmation_behavior.py
@@ -17,13 +17,16 @@ limitations under the License.
 import asyncio
 from types import SimpleNamespace
 
+from config.auth import BZM_USER_CONFIG_STATE_ATTR
 from models.result import BaseResult
 from tools.utils import Operations, require_confirmation
 
 
 class _ManagerWithConfirmation:
     def __init__(self, ctx, confirmation_mode: str = "DELETE"):
-        setattr(ctx, "user_config", {"confirmation_mode": confirmation_mode})
+        request_state = SimpleNamespace(**{BZM_USER_CONFIG_STATE_ATTR: {"confirmation_mode": confirmation_mode}})
+        request = SimpleNamespace(state=request_state)
+        setattr(ctx, "request_context", SimpleNamespace(request=request))
         self.ctx = ctx
 
     @require_confirmation(operation=Operations.CREATE)

--- a/tests/test_confirmation_behavior.py
+++ b/tests/test_confirmation_behavior.py
@@ -23,8 +23,8 @@ from tools.utils import Operations, require_confirmation
 
 class _ManagerWithConfirmation:
     def __init__(self, ctx, confirmation_mode: str = "DELETE"):
+        setattr(ctx, "user_config", {"confirmation_mode": confirmation_mode})
         self.ctx = ctx
-        self.user_config = {"confirmation_mode": confirmation_mode}
 
     @require_confirmation(operation=Operations.CREATE)
     async def do_create(self):

--- a/tests/test_hierarchy_and_consent.py
+++ b/tests/test_hierarchy_and_consent.py
@@ -17,10 +17,9 @@ limitations under the License.
 import asyncio
 from types import SimpleNamespace
 
-from config.file_access import LocalPathFileSource
-from config.storage import DefaultSessionScopeResolver
 from models.result import BaseResult
 from tools import account_manager, project_manager, workspace_manager, test_manager, execution_manager
+from tools import bridge
 from tools.account_manager import AccountManager
 from tools.execution_manager import ExecutionManager
 from tools.project_manager import ProjectManager
@@ -85,15 +84,37 @@ class TestHierarchyAndConsent:
 
         monkeypatch.setattr(test_manager, "api_request", fake_api_request)
         monkeypatch.setattr(test_manager.bridge, "read_project", fake_read_project)
-        manager = TestManager(
-            ctx=None,
-            file_access=LocalPathFileSource(),
-            scope_resolver=DefaultSessionScopeResolver(),
-        )
+        manager = TestManager(ctx=None)
 
         result = asyncio.run(manager.read(50))
 
         assert result.error == "Project validation failed"
+
+    def test_count_project_tests_does_not_require_file_access(self, monkeypatch):
+        async def fake_api_request(*args, **kwargs):
+            return BaseResult(result=[], total=4)
+
+        monkeypatch.setattr(test_manager, "api_request", fake_api_request)
+
+        total = asyncio.run(bridge.count_project_tests(token=None, ctx=None, project_id=2554395))
+
+        assert total == 4
+
+    def test_create_validates_project_without_file_access(self, monkeypatch):
+        async def fake_api_request(*args, **kwargs):
+            return BaseResult(result=[SimpleNamespace(test_id=99, test_name="dummy_test")])
+
+        async def fake_read_project(*args, **kwargs):
+            return BaseResult(result=["ok"])
+
+        monkeypatch.setattr(test_manager, "api_request", fake_api_request)
+        monkeypatch.setattr(test_manager.bridge, "read_project", fake_read_project)
+        manager = TestManager(ctx=None)
+
+        result = asyncio.run(manager.create("dummy_test", 2554395))
+
+        assert result.error is None
+        assert result.result[0].test_name == "dummy_test"
 
     def test_execution_start_stops_when_test_validation_fails(self, monkeypatch):
         called = {"api_request": False}

--- a/tests/test_hierarchy_and_consent.py
+++ b/tests/test_hierarchy_and_consent.py
@@ -25,7 +25,6 @@ from tools.account_manager import AccountManager
 from tools.execution_manager import ExecutionManager
 from tools.project_manager import ProjectManager
 from tools.test_manager import TestManager
-from tools.utils import register_confirm_mode, ConfirmMode
 from tools.workspace_manager import WorkspaceManager
 
 
@@ -98,7 +97,6 @@ class TestHierarchyAndConsent:
         assert result.error == "Project validation failed"
 
     def test_execution_start_stops_when_test_validation_fails(self, monkeypatch):
-        register_confirm_mode(ConfirmMode.DISABLE)
         called = {"api_request": False}
 
         async def fake_read_test(*args, **kwargs):
@@ -110,7 +108,11 @@ class TestHierarchyAndConsent:
 
         monkeypatch.setattr(execution_manager.bridge, "read_test", fake_read_test)
         monkeypatch.setattr(execution_manager, "api_request", fake_api_request)
-        manager = ExecutionManager(token=None, ctx=None)
+        manager = ExecutionManager(
+            token=None,
+            ctx=None,
+            user_config={"confirmation_mode": "DISABLE"},
+        )
 
         result = asyncio.run(manager.start(42))
 

--- a/tests/test_hierarchy_and_consent.py
+++ b/tests/test_hierarchy_and_consent.py
@@ -34,7 +34,7 @@ class TestHierarchyAndConsent:
             return BaseResult(result=[SimpleNamespace(ai_consent=False)])
 
         monkeypatch.setattr(account_manager, "api_request", fake_api_request)
-        manager = AccountManager(token=None, ctx=None)
+        manager = AccountManager(ctx=None)
 
         result = asyncio.run(manager.read(123))
 
@@ -50,7 +50,7 @@ class TestHierarchyAndConsent:
 
         monkeypatch.setattr(workspace_manager, "api_request", fake_api_request)
         monkeypatch.setattr(workspace_manager.bridge, "read_account", fake_read_account)
-        manager = WorkspaceManager(token=None, ctx=None)
+        manager = WorkspaceManager(ctx=None)
 
         result = asyncio.run(manager.read(55))
 
@@ -69,7 +69,7 @@ class TestHierarchyAndConsent:
         monkeypatch.setattr(project_manager, "api_request", fake_api_request)
         monkeypatch.setattr(project_manager.bridge, "read_workspace", fake_read_workspace)
         monkeypatch.setattr(project_manager.bridge, "count_project_tests", fake_count_project_tests)
-        manager = ProjectManager(token=None, ctx=None)
+        manager = ProjectManager(ctx=None)
 
         result = asyncio.run(manager.read(200))
 
@@ -86,7 +86,6 @@ class TestHierarchyAndConsent:
         monkeypatch.setattr(test_manager, "api_request", fake_api_request)
         monkeypatch.setattr(test_manager.bridge, "read_project", fake_read_project)
         manager = TestManager(
-            token=None,
             ctx=None,
             file_access=LocalPathFileSource(),
             scope_resolver=DefaultSessionScopeResolver(),
@@ -109,7 +108,6 @@ class TestHierarchyAndConsent:
         monkeypatch.setattr(execution_manager.bridge, "read_test", fake_read_test)
         monkeypatch.setattr(execution_manager, "api_request", fake_api_request)
         manager = ExecutionManager(
-            token=None,
             ctx=None,
             user_config={"confirmation_mode": "DISABLE"},
         )
@@ -132,7 +130,7 @@ class TestHierarchyAndConsent:
         monkeypatch.setattr(execution_manager, "api_request", fake_api_request)
         monkeypatch.setattr(execution_manager.bridge, "read_project", fake_read_project)
         monkeypatch.setattr(ExecutionManager, "_fetch_execution_status", fake_fetch_execution_status)
-        manager = ExecutionManager(token=None, ctx=None)
+        manager = ExecutionManager(ctx=None)
 
         result = asyncio.run(manager.read(909))
 

--- a/tests/test_hierarchy_and_consent.py
+++ b/tests/test_hierarchy_and_consent.py
@@ -107,10 +107,7 @@ class TestHierarchyAndConsent:
 
         monkeypatch.setattr(execution_manager.bridge, "read_test", fake_read_test)
         monkeypatch.setattr(execution_manager, "api_request", fake_api_request)
-        manager = ExecutionManager(
-            ctx=None,
-            user_config={"confirmation_mode": "DISABLE"},
-        )
+        manager = ExecutionManager(ctx=SimpleNamespace(user_config={"confirmation_mode": "DISABLE"}))
 
         result = asyncio.run(manager.start(42))
 

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -170,6 +170,18 @@ class TestBearerAuthMiddleware:
         assert response.status_code == 200
         assert response.json()["confirmation_mode"] == "CUD"
 
+    def test_confirmation_mode_none_falls_back_to_delete(self):
+        client = TestClient(self._app())
+        response = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer key-id:key-secret",
+                "Confirmation-Mode": "NONE",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["confirmation_mode"] == "DELETE"
+
     def test_confirmation_mode_not_persisted_between_requests_without_header(self):
         client = TestClient(self._app())
         first = client.post(

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -27,10 +27,12 @@ from starlette.testclient import TestClient
 from config.auth import (
     AuthError,
     BZM_USER_CONFIG_STATE_ATTR,
+    BZM_SESSION_ID_HEADER,
     BZM_TOKEN_STATE_ATTR,
     BearerAuthMiddleware,
     HttpAuthProvider,
     StdioAuthProvider,
+    clear_confirmation_mode_session_store,
     parse_authorization_header,
 )
 from config.file_access import LocalPathFileSource, StorageFileSource
@@ -124,6 +126,9 @@ class TestAuthProviders:
 
 
 class TestBearerAuthMiddleware:
+    def setup_method(self):
+        clear_confirmation_mode_session_store()
+
     def _app(self):
         async def ok(request: Request):
             token = getattr(request.state, BZM_TOKEN_STATE_ATTR, None)
@@ -169,6 +174,30 @@ class TestBearerAuthMiddleware:
         )
         assert response.status_code == 200
         assert response.json()["confirmation_mode"] == "CUD"
+
+    def test_uses_stored_confirmation_mode_for_same_session_without_header(self):
+        client = TestClient(self._app())
+        session_id = "session-abc"
+        first = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer key-id:key-secret",
+                "Confirmation-Mode": "CUD",
+                BZM_SESSION_ID_HEADER: session_id,
+            },
+        )
+        assert first.status_code == 200
+        assert first.json()["confirmation_mode"] == "CUD"
+
+        second = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer key-id:key-secret",
+                BZM_SESSION_ID_HEADER: session_id,
+            },
+        )
+        assert second.status_code == 200
+        assert second.json()["confirmation_mode"] == "CUD"
 
     def test_options_bypasses_auth(self):
         async def ok(_request: Request):

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -34,12 +34,13 @@ from config.auth import (
     parse_authorization_header,
 )
 from config.file_access import LocalPathFileSource, StorageFileSource
-from config.runtime import build_runtime
+from config.runtime import build_runtime, build_user_config
 from config.storage import (
     HttpSessionStorageProvider,
     InMemorySessionStorageProvider,
 )
 from config.token import BzmToken, BzmTokenError
+from models.manager import Manager
 
 
 class TestBearerCredentialParsing:
@@ -121,6 +122,29 @@ class TestAuthProviders:
 
         assert provider.get_token(make_ctx(token_a)).id == "account-a"
         assert provider.get_token(make_ctx(token_b)).id == "account-b"
+
+
+class TestManagerTokenResolution:
+    def test_manager_falls_back_to_request_state_token(self):
+        token = BzmToken("account-a", "secret-a")
+        request = SimpleNamespace(state=SimpleNamespace(**{BZM_TOKEN_STATE_ATTR: token}))
+        ctx = SimpleNamespace(request_context=SimpleNamespace(request=request))
+
+        manager = Manager(ctx)
+
+        assert manager.token is token
+
+
+class _StrictCtx:
+    """Mimics FastMCP Context where arbitrary attrs are disallowed."""
+
+    def __init__(self, request_context):
+        object.__setattr__(self, "request_context", request_context)
+
+    def __setattr__(self, name, value):
+        if name == "user_config":
+            raise ValueError('"Context" object has no field "user_config"')
+        object.__setattr__(self, name, value)
 
 
 class TestBearerAuthMiddleware:
@@ -258,3 +282,58 @@ class TestBuildRuntime:
         assert isinstance(runtime.auth, HttpAuthProvider)
         assert isinstance(runtime.storage, HttpSessionStorageProvider)
         assert isinstance(runtime.file_access, StorageFileSource)
+
+    def test_build_user_config_injects_request_context_for_stdio(self, monkeypatch):
+        monkeypatch.delenv("MCP_DOCKER", raising=False)
+        runtime = build_runtime("stdio")
+        ctx = SimpleNamespace(request_context=SimpleNamespace(request=None))
+
+        user_config = build_user_config(runtime, ctx)
+
+        assert "token" in user_config
+        assert user_config["confirmation_mode"] == "DELETE"
+        assert getattr(ctx.request_context, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
+
+    def test_build_user_config_merges_http_request_state(self, monkeypatch):
+        monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")
+        monkeypatch.setattr(HttpSessionStorageProvider, "ensure_available", lambda self: None)
+        runtime = build_runtime("streamable-http")
+        token = BzmToken("key-id", "key-secret")
+        request = SimpleNamespace(
+            state=SimpleNamespace(
+                **{
+                    BZM_TOKEN_STATE_ATTR: token,
+                    BZM_USER_CONFIG_STATE_ATTR: {"confirmation_mode": "CUD"},
+                }
+            )
+        )
+        ctx = SimpleNamespace(request_context=SimpleNamespace(request=request))
+
+        user_config = build_user_config(runtime, ctx)
+
+        assert user_config["confirmation_mode"] == "CUD"
+        assert user_config["token"] is token
+        assert getattr(ctx.request_context, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
+        assert getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
+
+    def test_build_user_config_hydrates_request_context_when_ctx_is_strict(self, monkeypatch):
+        monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")
+        monkeypatch.setattr(HttpSessionStorageProvider, "ensure_available", lambda self: None)
+        runtime = build_runtime("streamable-http")
+        token = BzmToken("key-id", "key-secret")
+        request = SimpleNamespace(
+            state=SimpleNamespace(
+                **{
+                    BZM_TOKEN_STATE_ATTR: token,
+                    BZM_USER_CONFIG_STATE_ATTR: {"confirmation_mode": "CUD"},
+                }
+            )
+        )
+        ctx = _StrictCtx(request_context=SimpleNamespace(request=request))
+
+        user_config = build_user_config(runtime, ctx)
+        manager = Manager(ctx)
+
+        assert user_config["token"] is token
+        assert getattr(ctx.request_context, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
+        assert manager.token is token

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -26,6 +26,7 @@ from starlette.testclient import TestClient
 
 from config.auth import (
     AuthError,
+    BZM_USER_CONFIG_STATE_ATTR,
     BZM_TOKEN_STATE_ATTR,
     BearerAuthMiddleware,
     HttpAuthProvider,
@@ -126,7 +127,13 @@ class TestBearerAuthMiddleware:
     def _app(self):
         async def ok(request: Request):
             token = getattr(request.state, BZM_TOKEN_STATE_ATTR, None)
-            return JSONResponse({"id": token.id if token else None})
+            user_config = getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, {})
+            return JSONResponse(
+                {
+                    "id": token.id if token else None,
+                    "confirmation_mode": user_config.get("confirmation_mode"),
+                }
+            )
 
         return BearerAuthMiddleware(Starlette(routes=[Route("/mcp", endpoint=ok, methods=["POST"])]))
 
@@ -149,6 +156,19 @@ class TestBearerAuthMiddleware:
         )
         assert response.status_code == 200
         assert response.json()["id"] == "key-id"
+        assert response.json()["confirmation_mode"] == "DELETE"
+
+    def test_valid_bearer_reads_confirmation_mode_header(self):
+        client = TestClient(self._app())
+        response = client.post(
+            "/mcp",
+            headers={
+                "Authorization": "Bearer key-id:key-secret",
+                "Confirmation-Mode": "CUD",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["confirmation_mode"] == "CUD"
 
     def test_options_bypasses_auth(self):
         async def ok(_request: Request):
@@ -188,12 +208,14 @@ class TestBuildRuntime:
         assert isinstance(stdio.auth, StdioAuthProvider)
         assert isinstance(stdio.storage, InMemorySessionStorageProvider)
         assert isinstance(stdio.file_access, LocalPathFileSource)
+        assert stdio.user_config["confirmation_mode"] == "DELETE"
 
         http = build_runtime("streamable-http")
         assert http.transport == "streamable-http"
         assert isinstance(http.auth, HttpAuthProvider)
         assert isinstance(http.storage, HttpSessionStorageProvider)
         assert isinstance(http.file_access, StorageFileSource)
+        assert http.user_config == {}
 
     def test_build_runtime_http_uses_storage_api_when_configured(self, monkeypatch):
         monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -34,7 +34,7 @@ from config.auth import (
     parse_authorization_header,
 )
 from config.file_access import LocalPathFileSource, StorageFileSource
-from config.runtime import build_runtime, build_user_config
+from config.runtime import build_runtime
 from config.storage import (
     HttpSessionStorageProvider,
     InMemorySessionStorageProvider,
@@ -283,18 +283,18 @@ class TestBuildRuntime:
         assert isinstance(runtime.storage, HttpSessionStorageProvider)
         assert isinstance(runtime.file_access, StorageFileSource)
 
-    def test_build_user_config_injects_request_context_for_stdio(self, monkeypatch):
+    def test_configure_context_injects_request_context_for_stdio(self, monkeypatch):
         monkeypatch.delenv("MCP_DOCKER", raising=False)
         runtime = build_runtime("stdio")
         ctx = SimpleNamespace(request_context=SimpleNamespace(request=None))
 
-        user_config = build_user_config(runtime, ctx)
+        user_config = runtime.configure_context(ctx)
 
         assert "token" in user_config
         assert user_config["confirmation_mode"] == "DELETE"
         assert getattr(ctx.request_context, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
 
-    def test_build_user_config_merges_http_request_state(self, monkeypatch):
+    def test_configure_context_merges_http_request_state(self, monkeypatch):
         monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")
         monkeypatch.setattr(HttpSessionStorageProvider, "ensure_available", lambda self: None)
         runtime = build_runtime("streamable-http")
@@ -309,14 +309,14 @@ class TestBuildRuntime:
         )
         ctx = SimpleNamespace(request_context=SimpleNamespace(request=request))
 
-        user_config = build_user_config(runtime, ctx)
+        user_config = runtime.configure_context(ctx)
 
         assert user_config["confirmation_mode"] == "CUD"
         assert user_config["token"] is token
         assert getattr(ctx.request_context, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
         assert getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, None) == user_config
 
-    def test_build_user_config_hydrates_request_context_when_ctx_is_strict(self, monkeypatch):
+    def test_configure_context_hydrates_request_context_when_ctx_is_strict(self, monkeypatch):
         monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")
         monkeypatch.setattr(HttpSessionStorageProvider, "ensure_available", lambda self: None)
         runtime = build_runtime("streamable-http")
@@ -331,7 +331,7 @@ class TestBuildRuntime:
         )
         ctx = _StrictCtx(request_context=SimpleNamespace(request=request))
 
-        user_config = build_user_config(runtime, ctx)
+        user_config = runtime.configure_context(ctx)
         manager = Manager(ctx)
 
         assert user_config["token"] is token

--- a/tests/test_http_auth.py
+++ b/tests/test_http_auth.py
@@ -27,12 +27,10 @@ from starlette.testclient import TestClient
 from config.auth import (
     AuthError,
     BZM_USER_CONFIG_STATE_ATTR,
-    BZM_SESSION_ID_HEADER,
     BZM_TOKEN_STATE_ATTR,
     BearerAuthMiddleware,
     HttpAuthProvider,
     StdioAuthProvider,
-    clear_confirmation_mode_session_store,
     parse_authorization_header,
 )
 from config.file_access import LocalPathFileSource, StorageFileSource
@@ -126,9 +124,6 @@ class TestAuthProviders:
 
 
 class TestBearerAuthMiddleware:
-    def setup_method(self):
-        clear_confirmation_mode_session_store()
-
     def _app(self):
         async def ok(request: Request):
             token = getattr(request.state, BZM_TOKEN_STATE_ATTR, None)
@@ -175,15 +170,13 @@ class TestBearerAuthMiddleware:
         assert response.status_code == 200
         assert response.json()["confirmation_mode"] == "CUD"
 
-    def test_uses_stored_confirmation_mode_for_same_session_without_header(self):
+    def test_confirmation_mode_not_persisted_between_requests_without_header(self):
         client = TestClient(self._app())
-        session_id = "session-abc"
         first = client.post(
             "/mcp",
             headers={
                 "Authorization": "Bearer key-id:key-secret",
                 "Confirmation-Mode": "CUD",
-                BZM_SESSION_ID_HEADER: session_id,
             },
         )
         assert first.status_code == 200
@@ -191,13 +184,10 @@ class TestBearerAuthMiddleware:
 
         second = client.post(
             "/mcp",
-            headers={
-                "Authorization": "Bearer key-id:key-secret",
-                BZM_SESSION_ID_HEADER: session_id,
-            },
+            headers={"Authorization": "Bearer key-id:key-secret"},
         )
         assert second.status_code == 200
-        assert second.json()["confirmation_mode"] == "CUD"
+        assert second.json()["confirmation_mode"] == "DELETE"
 
     def test_options_bypasses_auth(self):
         async def ok(_request: Request):

--- a/tests/test_main_transport.py
+++ b/tests/test_main_transport.py
@@ -20,7 +20,6 @@ class _DummyFastMCP:
 def _patch_mcp_server_dependencies(monkeypatch):
     monkeypatch.setattr(main, "init_telemetry", lambda *a, **k: None)
     monkeypatch.setattr(main, "get_token", lambda: object())
-    monkeypatch.setattr(main, "register_confirm_mode", lambda *a, **k: None)
     monkeypatch.setattr(main, "register_tools", lambda *a, **k: None)
     monkeypatch.setattr(main, "FastMCP", _DummyFastMCP)
     monkeypatch.setenv("BZM_STORAGE_API_BASE_URL", "https://mcp-storage.internal")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -127,3 +127,10 @@ class TestUploadAssetsHostedRejection:
         )
         assert "error" in result
         assert "No valid files found to upload" in result["error"]
+
+    def test_upload_assets_without_file_ports_returns_hosted_message(self):
+        manager = TestManager(ctx=None)
+        result = asyncio.run(
+            manager.upload_assets(1, ["/tmp/demo.jmx"], main_script=None)
+        )
+        assert result["error"] == HOSTED_FILE_ACCESS_MESSAGE

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -112,7 +112,6 @@ class TestRuntimeStorageWiring:
 class TestUploadAssetsHostedRejection:
     def test_upload_assets_returns_clear_error_on_http_storage(self):
         manager = TestManager(
-            token=None,
             ctx=None,
             file_access=StorageFileSource("https://mcp-storage.internal"),
             scope_resolver=DefaultSessionScopeResolver(),

--- a/tests/test_upload_assets_security.py
+++ b/tests/test_upload_assets_security.py
@@ -57,7 +57,6 @@ class TestUploadAssetsFileValidation:
         blocked_files = []
 
         manager = UploadAssetsManager(
-            token=None,
             ctx=None,
             file_access=LocalPathFileSource(),
             scope_resolver=DefaultSessionScopeResolver(),

--- a/tools/account_manager.py
+++ b/tools/account_manager.py
@@ -33,8 +33,13 @@ class AccountManager(Manager):
     # the format_accounts only expose minimum information to user
     # The read operation verify permissions and don't allow to share if don't have permissions.
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def read(self, account_id: Optional[int]) -> BaseResult:
         if not isinstance(account_id, int) or account_id < 1:
@@ -98,7 +103,11 @@ Hints:
 """
     )
     async def account(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        account_manager = AccountManager(runtime.auth.get_token(ctx), ctx)
+        account_manager = AccountManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/account_manager.py
+++ b/tools/account_manager.py
@@ -18,7 +18,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import ACCOUNTS_ENDPOINT, TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.account import format_accounts
 from models.manager import Manager
 from models.result import BaseResult
@@ -100,7 +100,7 @@ Hints:
 """
     )
     async def account(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         account_manager = AccountManager(ctx)
 
         async def _dispatch():

--- a/tools/account_manager.py
+++ b/tools/account_manager.py
@@ -35,16 +35,15 @@ class AccountManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def read(self, account_id: Optional[int]) -> BaseResult:
         if not isinstance(account_id, int) or account_id < 1:
             return BaseResult(error="Missing or invalid required argument 'account_id'. Expected integer.")
 
         account_result = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{ACCOUNTS_ENDPOINT}/{account_id}",
             result_formatter=format_accounts
@@ -73,7 +72,7 @@ class AccountManager(Manager):
         }
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{ACCOUNTS_ENDPOINT}",
             result_formatter=format_accounts,
@@ -101,10 +100,8 @@ Hints:
 """
     )
     async def account(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        account_manager = AccountManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        account_manager = AccountManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/account_manager.py
+++ b/tools/account_manager.py
@@ -18,8 +18,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import ACCOUNTS_ENDPOINT, TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.account import format_accounts
 from models.manager import Manager
 from models.result import BaseResult
@@ -35,18 +34,17 @@ class AccountManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def read(self, account_id: Optional[int]) -> BaseResult:
         if not isinstance(account_id, int) or account_id < 1:
             return BaseResult(error="Missing or invalid required argument 'account_id'. Expected integer.")
 
         account_result = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{ACCOUNTS_ENDPOINT}/{account_id}",
             result_formatter=format_accounts
@@ -75,7 +73,7 @@ class AccountManager(Manager):
         }
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{ACCOUNTS_ENDPOINT}",
             result_formatter=format_accounts,
@@ -104,9 +102,8 @@ Hints:
     )
     async def account(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         account_manager = AccountManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/billing_manager.py
+++ b/tools/billing_manager.py
@@ -19,7 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from models.manager import Manager
 from models.result import BaseResult
 from tools.billing_utils import calculate_test_cost
@@ -90,7 +90,7 @@ Hints:
 """
     )
     async def billing(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         billing_manager = BillingManager(ctx)
 
         async def _dispatch():

--- a/tools/billing_manager.py
+++ b/tools/billing_manager.py
@@ -19,8 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from models.manager import Manager
 from models.result import BaseResult
 from tools.billing_utils import calculate_test_cost
@@ -32,11 +31,10 @@ class BillingManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def calculate_cost_from_config(self, args: Dict) -> BaseResult:
         result = calculate_test_cost(args)
@@ -94,9 +92,8 @@ Hints:
     )
     async def billing(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         billing_manager = BillingManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/billing_manager.py
+++ b/tools/billing_manager.py
@@ -30,8 +30,13 @@ from tools.utils import format_sanitized_traceback
 
 class BillingManager(Manager):
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def calculate_cost_from_config(self, args: Dict) -> BaseResult:
         result = calculate_test_cost(args)
@@ -88,7 +93,11 @@ Hints:
 """
     )
     async def billing(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        billing_manager = BillingManager(runtime.auth.get_token(ctx), ctx)
+        billing_manager = BillingManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/billing_manager.py
+++ b/tools/billing_manager.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 
 import httpx
 from mcp.server.fastmcp import Context
@@ -32,9 +32,8 @@ class BillingManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def calculate_cost_from_config(self, args: Dict) -> BaseResult:
         result = calculate_test_cost(args)
@@ -91,10 +90,8 @@ Hints:
 """
     )
     async def billing(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        billing_manager = BillingManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        billing_manager = BillingManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/bridge.py
+++ b/tools/bridge.py
@@ -15,38 +15,71 @@ limitations under the License.
 """
 from mcp.server.fastmcp import Context
 
+from config.auth import BZM_TOKEN_STATE_ATTR, BZM_USER_CONFIG_STATE_ATTR
 from config.token import BzmToken
 from models.result import BaseResult
+from types import SimpleNamespace
 
 
 # NOTE: Imports are performed locally in each method to avoid cyclical import problems.
 # This file currently acts as a bridge between different managers to access specific methods,
 # primarily for validation of reference elements.
 
+def _with_token_context(ctx: Context, token: BzmToken) -> Context:
+    context = ctx or SimpleNamespace()
+    request_context = getattr(context, "request_context", None)
+    request = getattr(request_context, "request", None)
+    request_state = getattr(request, "state", None)
+
+    current_config = (
+        getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
+        or getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
+        or getattr(context, "user_config", None)
+        or {}
+    )
+    user_config = dict(current_config) if isinstance(current_config, dict) else {}
+    user_config["token"] = token
+
+    if request_context is not None:
+        setattr(request_context, BZM_USER_CONFIG_STATE_ATTR, dict(user_config))
+
+    if request_state is not None:
+        setattr(request_state, BZM_USER_CONFIG_STATE_ATTR, dict(user_config))
+        setattr(request_state, BZM_TOKEN_STATE_ATTR, token)
+
+    # Keep compatibility for non-FastMCP contexts used in tests.
+    try:
+        setattr(context, "user_config", user_config)
+    except Exception:
+        pass
+
+    return context
+
+
 async def read_account(token: BzmToken, ctx: Context, account_id: int) -> BaseResult:
     from tools.account_manager import AccountManager
-    return await AccountManager(ctx, user_config={"token": token}).read(account_id)
+    return await AccountManager(_with_token_context(ctx, token)).read(account_id)
 
 
 async def read_project(token: BzmToken, ctx: Context, project_id: int) -> BaseResult:
     from tools.project_manager import ProjectManager
-    return await ProjectManager(ctx, user_config={"token": token}).read(project_id)
+    return await ProjectManager(_with_token_context(ctx, token)).read(project_id)
 
 
 async def read_workspace(token: BzmToken, ctx: Context, workspace_id: int) -> BaseResult:
     from tools.workspace_manager import WorkspaceManager
-    return await WorkspaceManager(ctx, user_config={"token": token}).read(workspace_id)
+    return await WorkspaceManager(_with_token_context(ctx, token)).read(workspace_id)
 
 
 async def read_test(token: BzmToken, ctx: Context, test_id: int) -> BaseResult:
     from tools.test_manager import TestManager
-    return await TestManager(ctx, user_config={"token": token}).read(test_id)
+    return await TestManager(_with_token_context(ctx, token)).read(test_id)
 
 
 async def count_project_tests(token: BzmToken, ctx: Context, project_id: int) -> int:
     from tools.test_manager import TestManager
     return (
-        await TestManager(ctx, user_config={"token": token}).list(
+        await TestManager(_with_token_context(ctx, token)).list(
             project_id=project_id,
             limit=1,
             offset=0,
@@ -57,4 +90,4 @@ async def count_project_tests(token: BzmToken, ctx: Context, project_id: int) ->
 
 async def read_execution(token: BzmToken, ctx: Context, execution_id: int) -> BaseResult:
     from tools.execution_manager import ExecutionManager
-    return await ExecutionManager(ctx, user_config={"token": token}).read(execution_id)
+    return await ExecutionManager(_with_token_context(ctx, token)).read(execution_id)

--- a/tools/bridge.py
+++ b/tools/bridge.py
@@ -25,30 +25,36 @@ from models.result import BaseResult
 
 async def read_account(token: BzmToken, ctx: Context, account_id: int) -> BaseResult:
     from tools.account_manager import AccountManager
-    return await AccountManager(token, ctx).read(account_id)
+    return await AccountManager(ctx, user_config={"token": token}).read(account_id)
 
 
 async def read_project(token: BzmToken, ctx: Context, project_id: int) -> BaseResult:
     from tools.project_manager import ProjectManager
-    return await ProjectManager(token, ctx).read(project_id)
+    return await ProjectManager(ctx, user_config={"token": token}).read(project_id)
 
 
 async def read_workspace(token: BzmToken, ctx: Context, workspace_id: int) -> BaseResult:
     from tools.workspace_manager import WorkspaceManager
-    return await WorkspaceManager(token, ctx).read(workspace_id)
+    return await WorkspaceManager(ctx, user_config={"token": token}).read(workspace_id)
 
 
 async def read_test(token: BzmToken, ctx: Context, test_id: int) -> BaseResult:
     from tools.test_manager import TestManager
-    return await TestManager(token, ctx).read(test_id)
+    return await TestManager(ctx, user_config={"token": token}).read(test_id)
 
 
 async def count_project_tests(token: BzmToken, ctx: Context, project_id: int) -> int:
     from tools.test_manager import TestManager
     return (
-        await TestManager(token, ctx).list(project_id=project_id, limit=1, offset=0, control_ai_consent=False)).total
+        await TestManager(ctx, user_config={"token": token}).list(
+            project_id=project_id,
+            limit=1,
+            offset=0,
+            control_ai_consent=False,
+        )
+    ).total
 
 
 async def read_execution(token: BzmToken, ctx: Context, execution_id: int) -> BaseResult:
     from tools.execution_manager import ExecutionManager
-    return await ExecutionManager(token, ctx).read(execution_id)
+    return await ExecutionManager(ctx, user_config={"token": token}).read(execution_id)

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -19,7 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, EXECUTIONS_ENDPOINT, SUPPORT_MESSAGE
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.execution import format_executions, format_executions_detailed, format_executions_status
 from models.manager import Manager
 from models.result import BaseResult
@@ -505,7 +505,7 @@ Hints:
 """
     )
     async def execution(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         execution_manager = ExecutionManager(ctx)
         report_manager = ReportManager(ctx)
 

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -19,8 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, EXECUTIONS_ENDPOINT, SUPPORT_MESSAGE
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.execution import format_executions, format_executions_detailed, format_executions_status
 from models.manager import Manager
 from models.result import BaseResult
@@ -34,22 +33,22 @@ class ExecutionManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def _request_log_analyzer_api(self, method: str, execution_id: int,
                                         json_body: Optional[Dict[str, Any]] = None) -> BaseResult:
-        if not self.token:
+        token = self.user_config.get("token")
+        if not token:
             return BaseResult(
                 error="No API token. Set BLAZEMETER_API_KEY env var with file path or API_KEY_ID and API_KEY_SECRET secrets."
             )
 
         url = f"https://log-analyzer.blazemeter.com/analyzer/{execution_id}"
         headers = {
-            "Authorization": self.token.as_basic_auth(),
+            "Authorization": token.as_basic_auth(),
             "User-Agent": user_agent,
             "Accept": "application/json",
             "Content-Type": "application/json"
@@ -111,14 +110,14 @@ class ExecutionManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'test_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        test_result = await bridge.read_test(self.token, self.ctx, test_id)
+        test_result = await bridge.read_test(self.user_config.get("token"), self.ctx, test_id)
         if test_result.error:
             return test_result
 
         parameters = {"delayedStart": delayed_start_ready}
         start_body = {"isDebugRun": is_debug_run}
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "POST",
             f"/tests/{test_id}/start",
             result_formatter=format_executions,
@@ -131,7 +130,7 @@ class ExecutionManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         execution_response = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{execution_id}",
             result_formatter=format_executions_detailed,
@@ -142,7 +141,7 @@ class ExecutionManager(Manager):
 
         execution_element = execution_response.result[0]
 
-        project_result = await bridge.read_project(self.token, self.ctx, execution_element.project_id)
+        project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, execution_element.project_id)
         if project_result.error:
             return project_result
 
@@ -162,7 +161,7 @@ class ExecutionManager(Manager):
     async def _fetch_execution_status(self, execution_id: int) -> BaseResult:
         parameters = {"level": 200, "events": False}
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{execution_id}/status",
             result_formatter=format_executions_status,
@@ -196,7 +195,7 @@ class ExecutionManager(Manager):
         if not isinstance(limit, int) or not isinstance(offset, int):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
-        test_result = await bridge.read_test(self.token, self.ctx, test_id)
+        test_result = await bridge.read_test(self.user_config.get("token"), self.ctx, test_id)
         if test_result.error:
             return test_result
 
@@ -208,7 +207,7 @@ class ExecutionManager(Manager):
         }
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}",
             result_formatter=format_executions,
@@ -221,20 +220,25 @@ class ExecutionManager(Manager):
         account_id = args.get("account_id")
         if not isinstance(account_id, int) or account_id < 1:
             return BaseResult(error="Missing or invalid required argument 'account_id'. Expected integer.")
-        account_data = await bridge.read_account(self.token, self.ctx, account_id)
+        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
         if account_data.error:
             return account_data
 
-        return await search_utils.test_execution_search("master", self.token, account_id, args)
+        return await search_utils.test_execution_search("master", self.user_config.get("token"), account_id, args)
 
     async def search_filter_values(self, account_id: int, filter_names: List[str]) -> BaseResult:
 
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.token, self.ctx, account_id)
+        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
         if account_data.error:
             return account_data
 
-        return await search_utils.test_execution_search_filter_values("master", account_id, self.token, filter_names)
+        return await search_utils.test_execution_search_filter_values(
+            "master",
+            account_id,
+            self.user_config.get("token"),
+            filter_names,
+        )
 
     async def ai_analysis(self, execution_id: Optional[int]) -> BaseResult:
         if not isinstance(execution_id, int) or execution_id < 1:
@@ -401,7 +405,7 @@ class ExecutionManager(Manager):
         if not isinstance(execution_id, int) or execution_id < 1:
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
-        report_manager = ReportManager(self.token, self.ctx)
+        report_manager = ReportManager(self.ctx, user_config=self.user_config)
         summary_result = await report_manager.read_summary(execution_id)
         error_result = await report_manager.read_error(execution_id)
         stats_result = await report_manager.read_request_stats(execution_id)
@@ -503,14 +507,12 @@ Hints:
     )
     async def execution(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         execution_manager = ExecutionManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
         report_manager = ReportManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -32,8 +32,13 @@ from tools.utils import api_request, timeout, user_agent, format_sanitized_trace
 
 class ExecutionManager(Manager):
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def _request_log_analyzer_api(self, method: str, execution_id: int,
                                         json_body: Optional[Dict[str, Any]] = None) -> BaseResult:
@@ -497,8 +502,16 @@ Hints:
 """
     )
     async def execution(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        execution_manager = ExecutionManager(runtime.auth.get_token(ctx), ctx)
-        report_manager = ReportManager(runtime.auth.get_token(ctx), ctx)
+        execution_manager = ExecutionManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
+        report_manager = ReportManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/execution_manager.py
+++ b/tools/execution_manager.py
@@ -34,13 +34,12 @@ class ExecutionManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def _request_log_analyzer_api(self, method: str, execution_id: int,
                                         json_body: Optional[Dict[str, Any]] = None) -> BaseResult:
-        token = self.user_config.get("token")
+        token = self.token
         if not token:
             return BaseResult(
                 error="No API token. Set BLAZEMETER_API_KEY env var with file path or API_KEY_ID and API_KEY_SECRET secrets."
@@ -110,14 +109,14 @@ class ExecutionManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'test_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        test_result = await bridge.read_test(self.user_config.get("token"), self.ctx, test_id)
+        test_result = await bridge.read_test(self.token, self.ctx, test_id)
         if test_result.error:
             return test_result
 
         parameters = {"delayedStart": delayed_start_ready}
         start_body = {"isDebugRun": is_debug_run}
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "POST",
             f"/tests/{test_id}/start",
             result_formatter=format_executions,
@@ -130,7 +129,7 @@ class ExecutionManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         execution_response = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{execution_id}",
             result_formatter=format_executions_detailed,
@@ -141,7 +140,7 @@ class ExecutionManager(Manager):
 
         execution_element = execution_response.result[0]
 
-        project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, execution_element.project_id)
+        project_result = await bridge.read_project(self.token, self.ctx, execution_element.project_id)
         if project_result.error:
             return project_result
 
@@ -161,7 +160,7 @@ class ExecutionManager(Manager):
     async def _fetch_execution_status(self, execution_id: int) -> BaseResult:
         parameters = {"level": 200, "events": False}
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{execution_id}/status",
             result_formatter=format_executions_status,
@@ -195,7 +194,7 @@ class ExecutionManager(Manager):
         if not isinstance(limit, int) or not isinstance(offset, int):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
-        test_result = await bridge.read_test(self.user_config.get("token"), self.ctx, test_id)
+        test_result = await bridge.read_test(self.token, self.ctx, test_id)
         if test_result.error:
             return test_result
 
@@ -207,7 +206,7 @@ class ExecutionManager(Manager):
         }
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}",
             result_formatter=format_executions,
@@ -220,23 +219,23 @@ class ExecutionManager(Manager):
         account_id = args.get("account_id")
         if not isinstance(account_id, int) or account_id < 1:
             return BaseResult(error="Missing or invalid required argument 'account_id'. Expected integer.")
-        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
+        account_data = await bridge.read_account(self.token, self.ctx, account_id)
         if account_data.error:
             return account_data
 
-        return await search_utils.test_execution_search("master", self.user_config.get("token"), account_id, args)
+        return await search_utils.test_execution_search("master", self.token, account_id, args)
 
     async def search_filter_values(self, account_id: int, filter_names: List[str]) -> BaseResult:
 
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
+        account_data = await bridge.read_account(self.token, self.ctx, account_id)
         if account_data.error:
             return account_data
 
         return await search_utils.test_execution_search_filter_values(
             "master",
             account_id,
-            self.user_config.get("token"),
+            self.token,
             filter_names,
         )
 
@@ -405,7 +404,7 @@ class ExecutionManager(Manager):
         if not isinstance(execution_id, int) or execution_id < 1:
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
-        report_manager = ReportManager(self.ctx, user_config=self.user_config)
+        report_manager = ReportManager(self.ctx)
         summary_result = await report_manager.read_summary(execution_id)
         error_result = await report_manager.read_error(execution_id)
         stats_result = await report_manager.read_request_stats(execution_id)
@@ -506,14 +505,9 @@ Hints:
 """
     )
     async def execution(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        execution_manager = ExecutionManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
-        report_manager = ReportManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        execution_manager = ExecutionManager(ctx)
+        report_manager = ReportManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/help_manager.py
+++ b/tools/help_manager.py
@@ -16,7 +16,7 @@ limitations under the License.
 import asyncio
 from copy import deepcopy
 from itertools import chain
-from typing import Optional, Any, Dict, List
+from typing import Any, Dict, List
 
 import httpx
 from mcp.server.fastmcp import Context
@@ -47,9 +47,8 @@ class HelpManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def _load_help_tree(self):
         help_index_url = HELP_INDEX_URL
@@ -294,10 +293,8 @@ Hints:
         if args is None:
             args = {}
 
-        help_manager = HelpManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        help_manager = HelpManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/help_manager.py
+++ b/tools/help_manager.py
@@ -24,7 +24,7 @@ from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE, \
     HELP_INDEX_URL, HELP_TOC_URL, HELP_BASE_CONTENT_URL
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.help import format_help_info
 from models.manager import Manager
 from models.result import BaseResult
@@ -293,7 +293,7 @@ Hints:
         if args is None:
             args = {}
 
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         help_manager = HelpManager(ctx)
 
         async def _dispatch():

--- a/tools/help_manager.py
+++ b/tools/help_manager.py
@@ -24,8 +24,7 @@ from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE, \
     HELP_INDEX_URL, HELP_TOC_URL, HELP_BASE_CONTENT_URL
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.help import format_help_info
 from models.manager import Manager
 from models.result import BaseResult
@@ -47,11 +46,10 @@ class HelpManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def _load_help_tree(self):
         help_index_url = HELP_INDEX_URL
@@ -297,9 +295,8 @@ Hints:
             args = {}
 
         help_manager = HelpManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/help_manager.py
+++ b/tools/help_manager.py
@@ -45,8 +45,13 @@ class HelpManager(Manager):
         "Help content is sourced from curated BlazeMeter documentation domains and is trusted by design."
     )
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def _load_help_tree(self):
         help_index_url = HELP_INDEX_URL
@@ -291,7 +296,11 @@ Hints:
         if args is None:
             args = {}
 
-        help_manager = HelpManager(runtime.auth.get_token(ctx), ctx)
+        help_manager = HelpManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/project_manager.py
+++ b/tools/project_manager.py
@@ -19,8 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, PROJECTS_ENDPOINT
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.project import format_projects
 from models.manager import Manager
 from models.result import BaseResult
@@ -33,18 +32,17 @@ class ProjectManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def read(self, project_id: Optional[int]) -> BaseResult:
         if not isinstance(project_id, int) or project_id < 1:
             return BaseResult(error="Missing or invalid required argument 'project_id'. Expected integer.")
 
         project_result = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{PROJECTS_ENDPOINT}/{project_id}",
             result_formatter=format_projects
@@ -55,12 +53,12 @@ class ProjectManager(Manager):
         project_element = project_result.result[0]
 
         # Check if it's valid or allowed
-        workspace_result = await bridge.read_workspace(self.token, self.ctx, project_element.workspace_id)
+        workspace_result = await bridge.read_workspace(self.user_config.get("token"), self.ctx, project_element.workspace_id)
         if workspace_result.error:
             return workspace_result
 
         # Get the amount of test
-        project_element.tests_count = await bridge.count_project_tests(self.token, self.ctx, project_id)
+        project_element.tests_count = await bridge.count_project_tests(self.user_config.get("token"), self.ctx, project_id)
         return project_result
 
     async def list(self, workspace_id: Optional[int], limit: int = 50, offset: int = 0) -> BaseResult:
@@ -70,7 +68,7 @@ class ProjectManager(Manager):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
         # Check if it's valid or allowed
-        workspace_result = await bridge.read_workspace(self.token, self.ctx, workspace_id)
+        workspace_result = await bridge.read_workspace(self.user_config.get("token"), self.ctx, workspace_id)
         if workspace_result.error:
             return workspace_result
 
@@ -82,7 +80,7 @@ class ProjectManager(Manager):
         }
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{PROJECTS_ENDPOINT}",
             result_formatter=format_projects,
@@ -112,9 +110,8 @@ Hints:
     )
     async def project(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         project_manager = ProjectManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/project_manager.py
+++ b/tools/project_manager.py
@@ -19,7 +19,7 @@ import httpx
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import TOOLS_PREFIX, PROJECTS_ENDPOINT
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.project import format_projects
 from models.manager import Manager
 from models.result import BaseResult
@@ -108,7 +108,7 @@ Hints:
 """
     )
     async def project(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         project_manager = ProjectManager(ctx)
 
         async def _dispatch():

--- a/tools/project_manager.py
+++ b/tools/project_manager.py
@@ -33,16 +33,15 @@ class ProjectManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def read(self, project_id: Optional[int]) -> BaseResult:
         if not isinstance(project_id, int) or project_id < 1:
             return BaseResult(error="Missing or invalid required argument 'project_id'. Expected integer.")
 
         project_result = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{PROJECTS_ENDPOINT}/{project_id}",
             result_formatter=format_projects
@@ -53,12 +52,12 @@ class ProjectManager(Manager):
         project_element = project_result.result[0]
 
         # Check if it's valid or allowed
-        workspace_result = await bridge.read_workspace(self.user_config.get("token"), self.ctx, project_element.workspace_id)
+        workspace_result = await bridge.read_workspace(self.token, self.ctx, project_element.workspace_id)
         if workspace_result.error:
             return workspace_result
 
         # Get the amount of test
-        project_element.tests_count = await bridge.count_project_tests(self.user_config.get("token"), self.ctx, project_id)
+        project_element.tests_count = await bridge.count_project_tests(self.token, self.ctx, project_id)
         return project_result
 
     async def list(self, workspace_id: Optional[int], limit: int = 50, offset: int = 0) -> BaseResult:
@@ -68,7 +67,7 @@ class ProjectManager(Manager):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
         # Check if it's valid or allowed
-        workspace_result = await bridge.read_workspace(self.user_config.get("token"), self.ctx, workspace_id)
+        workspace_result = await bridge.read_workspace(self.token, self.ctx, workspace_id)
         if workspace_result.error:
             return workspace_result
 
@@ -80,7 +79,7 @@ class ProjectManager(Manager):
         }
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{PROJECTS_ENDPOINT}",
             result_formatter=format_projects,
@@ -109,10 +108,8 @@ Hints:
 """
     )
     async def project(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        project_manager = ProjectManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        project_manager = ProjectManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/project_manager.py
+++ b/tools/project_manager.py
@@ -31,8 +31,13 @@ from tools.utils import api_request, format_sanitized_traceback
 
 class ProjectManager(Manager):
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def read(self, project_id: Optional[int]) -> BaseResult:
         if not isinstance(project_id, int) or project_id < 1:
@@ -106,7 +111,11 @@ Hints:
 """
     )
     async def project(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        project_manager = ProjectManager(runtime.auth.get_token(ctx), ctx)
+        project_manager = ProjectManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/report_manager.py
+++ b/tools/report_manager.py
@@ -38,9 +38,8 @@ class ReportManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     def _extract_execution_name(self, execution_result: BaseResult) -> Optional[str]:
         """Extract execution name from execution result if available."""
@@ -56,7 +55,7 @@ class ReportManager(Manager):
                 execution_result.result[0].get("result").archived)
 
     async def read_summary(self, master_id: int):
-        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -69,7 +68,7 @@ class ReportManager(Manager):
         execution_name = self._extract_execution_name(execution_result)
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/default/summary",
             result_formatter=format_summary_report,
@@ -88,7 +87,7 @@ class ReportManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -99,7 +98,7 @@ class ReportManager(Manager):
             )
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/errorsreport/data",
             result_formatter=format_error_report,
@@ -118,7 +117,7 @@ class ReportManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -130,7 +129,7 @@ class ReportManager(Manager):
 
         # Get request stats data from API with formatter
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/aggregatereport/data",
             result_formatter=format_request_stats,
@@ -150,7 +149,7 @@ class ReportManager(Manager):
         if not isinstance(master_id, int) or master_id < 1:
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
-        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -162,7 +161,7 @@ class ReportManager(Manager):
         execution_name = self._extract_execution_name(execution_result)
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/anomalies/stats",
             result_formatter=format_anomalies_stats,

--- a/tools/report_manager.py
+++ b/tools/report_manager.py
@@ -18,7 +18,6 @@ from typing import Any, Optional
 from mcp.server.fastmcp import Context
 
 from config.blazemeter import EXECUTIONS_ENDPOINT
-from config.token import BzmToken
 from formatters.execution import (
     format_summary_report,
     format_request_stats,
@@ -38,11 +37,10 @@ class ReportManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     def _extract_execution_name(self, execution_result: BaseResult) -> Optional[str]:
         """Extract execution name from execution result if available."""
@@ -58,7 +56,7 @@ class ReportManager(Manager):
                 execution_result.result[0].get("result").archived)
 
     async def read_summary(self, master_id: int):
-        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -71,7 +69,7 @@ class ReportManager(Manager):
         execution_name = self._extract_execution_name(execution_result)
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/default/summary",
             result_formatter=format_summary_report,
@@ -90,7 +88,7 @@ class ReportManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -101,7 +99,7 @@ class ReportManager(Manager):
             )
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/errorsreport/data",
             result_formatter=format_error_report,
@@ -120,7 +118,7 @@ class ReportManager(Manager):
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
         # Check if it's valid or allowed
-        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -132,7 +130,7 @@ class ReportManager(Manager):
 
         # Get request stats data from API with formatter
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/reports/aggregatereport/data",
             result_formatter=format_request_stats,
@@ -152,7 +150,7 @@ class ReportManager(Manager):
         if not isinstance(master_id, int) or master_id < 1:
             return BaseResult(error="Missing or invalid required argument 'execution_id'. Expected integer.")
 
-        execution_result = await bridge.read_execution(self.token, self.ctx, master_id)
+        execution_result = await bridge.read_execution(self.user_config.get("token"), self.ctx, master_id)
         if execution_result.error:
             return execution_result
 
@@ -164,7 +162,7 @@ class ReportManager(Manager):
         execution_name = self._extract_execution_name(execution_result)
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{EXECUTIONS_ENDPOINT}/{master_id}/anomalies/stats",
             result_formatter=format_anomalies_stats,

--- a/tools/report_manager.py
+++ b/tools/report_manager.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Optional
+from typing import Any, Optional
 
 from mcp.server.fastmcp import Context
 
@@ -36,8 +36,13 @@ EXECUTION_ARCHIVED_MSG = ("Execution report is archived. It is not possible to r
 
 class ReportManager(Manager):
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     def _extract_execution_name(self, execution_result: BaseResult) -> Optional[str]:
         """Extract execution name from execution result if available."""

--- a/tools/skills_manager.py
+++ b/tools/skills_manager.py
@@ -45,9 +45,8 @@ class SkillsManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     @staticmethod
     async def list_skills() -> BaseResult:
@@ -207,10 +206,8 @@ Hints:
         if args is None:
             args = {}
 
-        skills_manager = SkillsManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        skills_manager = SkillsManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/skills_manager.py
+++ b/tools/skills_manager.py
@@ -22,8 +22,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from models.manager import Manager
 from models.result import BaseResult
 from telemetry import run_tool
@@ -45,11 +44,10 @@ class SkillsManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     @staticmethod
     async def list_skills() -> BaseResult:
@@ -210,9 +208,8 @@ Hints:
             args = {}
 
         skills_manager = SkillsManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/skills_manager.py
+++ b/tools/skills_manager.py
@@ -43,8 +43,13 @@ class SkillsManager(Manager):
         "Skills content is sourced from curated repository resources and is trusted by design."
     )
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     @staticmethod
     async def list_skills() -> BaseResult:
@@ -204,7 +209,11 @@ Hints:
         if args is None:
             args = {}
 
-        skills_manager = SkillsManager(runtime.auth.get_token(ctx), ctx)
+        skills_manager = SkillsManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/skills_manager.py
+++ b/tools/skills_manager.py
@@ -22,7 +22,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, SUPPORT_MESSAGE
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from models.manager import Manager
 from models.result import BaseResult
 from telemetry import run_tool
@@ -206,7 +206,7 @@ Hints:
         if args is None:
             args = {}
 
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         skills_manager = SkillsManager(ctx)
 
         async def _dispatch():

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -25,7 +25,7 @@ from mcp.server.fastmcp import Context
 from config.blazemeter import TESTS_ENDPOINT, TOOLS_PREFIX
 from config.file_access import FileAccessPort
 from config.security import detect_sensitive_upload_path_reason
-from config.storage import SessionScopeResolverPort
+from config.storage import HOSTED_FILE_ACCESS_MESSAGE, SessionScopeResolverPort
 from config.runtime import AppRuntime
 from formatters.failure_criteria_labels import failure_criteria_meta_payload
 from formatters.test import format_tests
@@ -54,10 +54,12 @@ class TestManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        file_access: FileAccessPort,
-        scope_resolver: SessionScopeResolverPort,
+        file_access: Optional[FileAccessPort] = None,
+        scope_resolver: Optional[SessionScopeResolverPort] = None,
     ):
         super().__init__(ctx)
+        # Upload ports are stdio-only today. HTTP create/list/read must work
+        # without them; hosted file upload will be a separate tool later.
         self.file_access = file_access
         self.scope_resolver = scope_resolver
 
@@ -219,6 +221,8 @@ class TestManager(Manager):
             return {
                 "error": "Missing or invalid required argument 'file_paths'. Expected non-empty list."
             }
+        if self.file_access is None or self.scope_resolver is None:
+            return {"error": HOSTED_FILE_ACCESS_MESSAGE}
 
         # Check if it's valid or allowed
         test_data = await self.read(test_id)
@@ -668,7 +672,12 @@ Hints:
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         runtime.configure_context(ctx)
-        test_manager = TestManager(ctx, runtime.file_access, runtime.scope_resolver)
+        if runtime.transport == "stdio":
+            test_manager = TestManager(
+                ctx, runtime.file_access, runtime.scope_resolver
+            )
+        else:
+            test_manager = TestManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -58,8 +58,9 @@ class TestManager(Manager):
         ctx: Context,
         file_access: FileAccessPort,
         scope_resolver: SessionScopeResolverPort,
+        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx)
+        super().__init__(token, ctx, user_config=user_config)
         self.file_access = file_access
         self.scope_resolver = scope_resolver
 
@@ -674,6 +675,7 @@ Hints:
             ctx,
             runtime.file_access,
             runtime.scope_resolver,
+            user_config=runtime.user_config,
         )
 
         async def _dispatch():

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -26,7 +26,7 @@ from config.blazemeter import TESTS_ENDPOINT, TOOLS_PREFIX
 from config.file_access import FileAccessPort
 from config.security import detect_sensitive_upload_path_reason
 from config.storage import SessionScopeResolverPort
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.failure_criteria_labels import failure_criteria_meta_payload
 from formatters.test import format_tests
 from models.failure_criteria import (
@@ -667,7 +667,7 @@ Hints:
 """,
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         test_manager = TestManager(ctx, runtime.file_access, runtime.scope_resolver)
 
         async def _dispatch():

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -56,14 +56,13 @@ class TestManager(Manager):
         ctx: Context,
         file_access: FileAccessPort,
         scope_resolver: SessionScopeResolverPort,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
         self.file_access = file_access
         self.scope_resolver = scope_resolver
 
     def _current_scope(self):
-        return self.scope_resolver.resolve(self.ctx, self.user_config.get("token"))
+        return self.scope_resolver.resolve(self.ctx, self.token)
 
     async def read(self, test_id: Optional[int]) -> BaseResult:
         if not isinstance(test_id, int) or test_id < 1:
@@ -72,7 +71,7 @@ class TestManager(Manager):
             )
 
         test_result = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{TESTS_ENDPOINT}/{test_id}",
             result_formatter=format_tests,
@@ -82,7 +81,7 @@ class TestManager(Manager):
         else:
             # Check if it's valid or allowed
             project_result = await bridge.read_project(
-                self.user_config.get("token"), self.ctx, test_result.result[0].project_id
+                self.token, self.ctx, test_result.result[0].project_id
             )
             if project_result.error:
                 return project_result
@@ -103,7 +102,7 @@ class TestManager(Manager):
             )
 
         # Check if it's valid or allowed
-        project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, project_id)
+        project_result = await bridge.read_project(self.token, self.ctx, project_id)
         if project_result.error:
             return project_result
 
@@ -118,7 +117,7 @@ class TestManager(Manager):
             },
         }
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "POST",
             f"{TESTS_ENDPOINT}",
             result_formatter=format_tests,
@@ -137,7 +136,7 @@ class TestManager(Manager):
             return test_result
         else:
             test_deleted_result = await api_request(
-                self.user_config.get("token"), "DELETE", f"{TESTS_ENDPOINT}/{test_id}"
+                self.token, "DELETE", f"{TESTS_ENDPOINT}/{test_id}"
             )
             if test_deleted_result.error:
                 return test_deleted_result
@@ -314,7 +313,7 @@ class TestManager(Manager):
             endpoint = f"{TESTS_ENDPOINT}/{test_id}/files"
             logger.debug(f"Uploading to endpoint: {endpoint}")
 
-            result = await api_request(self.user_config.get("token"), "POST", endpoint, files=files)
+            result = await api_request(self.token, "POST", endpoint, files=files)
 
             logger.debug(f"Upload result: {result}")
 
@@ -338,7 +337,7 @@ class TestManager(Manager):
             }
 
             return await api_request(
-                self.user_config.get("token"), "PATCH", f"{TESTS_ENDPOINT}/{test_id}", json=config_update
+                self.token, "PATCH", f"{TESTS_ENDPOINT}/{test_id}", json=config_update
             )
 
         except Exception as e:
@@ -393,7 +392,7 @@ class TestManager(Manager):
 
         if control_ai_consent:
             # Check if it's valid or allowed
-            project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, project_id)
+            project_result = await bridge.read_project(self.token, self.ctx, project_id)
             if project_result.error:
                 return project_result
 
@@ -405,7 +404,7 @@ class TestManager(Manager):
         }
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{TESTS_ENDPOINT}",
             result_formatter=format_tests,
@@ -419,24 +418,24 @@ class TestManager(Manager):
             return BaseResult(
                 error="Missing or invalid required argument 'account_id'. Expected integer."
             )
-        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
+        account_data = await bridge.read_account(self.token, self.ctx, account_id)
         if account_data.error:
             return account_data
 
         return await search_utils.test_execution_search(
-            "test-union", self.user_config.get("token"), account_id, args
+            "test-union", self.token, account_id, args
         )
 
     async def search_filter_values(
         self, account_id: int, filter_names: List[str]
     ) -> BaseResult:
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
+        account_data = await bridge.read_account(self.token, self.ctx, account_id)
         if account_data.error:
             return account_data
 
         return await search_utils.test_execution_search_filter_values(
-            "test-union", account_id, self.user_config.get("token"), filter_names
+            "test-union", account_id, self.token, filter_names
         )
 
     @staticmethod
@@ -521,7 +520,7 @@ class TestManager(Manager):
         configuration_body = {"overrideExecutions": override_executions}
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "PATCH",
             f"{TESTS_ENDPOINT}/{performance_test.test_id}",
             result_formatter=format_tests,
@@ -552,7 +551,7 @@ class TestManager(Manager):
             configuration, fc
         )
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "PATCH",
             f"{TESTS_ENDPOINT}/{test_id}",
             result_formatter=format_tests,
@@ -668,12 +667,8 @@ Hints:
 """,
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
-        test_manager = TestManager(
-            ctx,
-            runtime.file_access,
-            runtime.scope_resolver,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        test_manager = TestManager(ctx, runtime.file_access, runtime.scope_resolver)
 
         async def _dispatch():
             match action:

--- a/tools/test_manager.py
+++ b/tools/test_manager.py
@@ -26,8 +26,7 @@ from config.blazemeter import TESTS_ENDPOINT, TOOLS_PREFIX
 from config.file_access import FileAccessPort
 from config.security import detect_sensitive_upload_path_reason
 from config.storage import SessionScopeResolverPort
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.failure_criteria_labels import failure_criteria_meta_payload
 from formatters.test import format_tests
 from models.failure_criteria import (
@@ -54,18 +53,17 @@ class TestManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         file_access: FileAccessPort,
         scope_resolver: SessionScopeResolverPort,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
         self.file_access = file_access
         self.scope_resolver = scope_resolver
 
     def _current_scope(self):
-        return self.scope_resolver.resolve(self.ctx, self.token)
+        return self.scope_resolver.resolve(self.ctx, self.user_config.get("token"))
 
     async def read(self, test_id: Optional[int]) -> BaseResult:
         if not isinstance(test_id, int) or test_id < 1:
@@ -74,7 +72,7 @@ class TestManager(Manager):
             )
 
         test_result = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{TESTS_ENDPOINT}/{test_id}",
             result_formatter=format_tests,
@@ -84,7 +82,7 @@ class TestManager(Manager):
         else:
             # Check if it's valid or allowed
             project_result = await bridge.read_project(
-                self.token, self.ctx, test_result.result[0].project_id
+                self.user_config.get("token"), self.ctx, test_result.result[0].project_id
             )
             if project_result.error:
                 return project_result
@@ -105,7 +103,7 @@ class TestManager(Manager):
             )
 
         # Check if it's valid or allowed
-        project_result = await bridge.read_project(self.token, self.ctx, project_id)
+        project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, project_id)
         if project_result.error:
             return project_result
 
@@ -120,7 +118,7 @@ class TestManager(Manager):
             },
         }
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "POST",
             f"{TESTS_ENDPOINT}",
             result_formatter=format_tests,
@@ -139,7 +137,7 @@ class TestManager(Manager):
             return test_result
         else:
             test_deleted_result = await api_request(
-                self.token, "DELETE", f"{TESTS_ENDPOINT}/{test_id}"
+                self.user_config.get("token"), "DELETE", f"{TESTS_ENDPOINT}/{test_id}"
             )
             if test_deleted_result.error:
                 return test_deleted_result
@@ -316,7 +314,7 @@ class TestManager(Manager):
             endpoint = f"{TESTS_ENDPOINT}/{test_id}/files"
             logger.debug(f"Uploading to endpoint: {endpoint}")
 
-            result = await api_request(self.token, "POST", endpoint, files=files)
+            result = await api_request(self.user_config.get("token"), "POST", endpoint, files=files)
 
             logger.debug(f"Upload result: {result}")
 
@@ -340,7 +338,7 @@ class TestManager(Manager):
             }
 
             return await api_request(
-                self.token, "PATCH", f"{TESTS_ENDPOINT}/{test_id}", json=config_update
+                self.user_config.get("token"), "PATCH", f"{TESTS_ENDPOINT}/{test_id}", json=config_update
             )
 
         except Exception as e:
@@ -395,7 +393,7 @@ class TestManager(Manager):
 
         if control_ai_consent:
             # Check if it's valid or allowed
-            project_result = await bridge.read_project(self.token, self.ctx, project_id)
+            project_result = await bridge.read_project(self.user_config.get("token"), self.ctx, project_id)
             if project_result.error:
                 return project_result
 
@@ -407,7 +405,7 @@ class TestManager(Manager):
         }
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{TESTS_ENDPOINT}",
             result_formatter=format_tests,
@@ -421,24 +419,24 @@ class TestManager(Manager):
             return BaseResult(
                 error="Missing or invalid required argument 'account_id'. Expected integer."
             )
-        account_data = await bridge.read_account(self.token, self.ctx, account_id)
+        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
         if account_data.error:
             return account_data
 
         return await search_utils.test_execution_search(
-            "test-union", self.token, account_id, args
+            "test-union", self.user_config.get("token"), account_id, args
         )
 
     async def search_filter_values(
         self, account_id: int, filter_names: List[str]
     ) -> BaseResult:
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.token, self.ctx, account_id)
+        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
         if account_data.error:
             return account_data
 
         return await search_utils.test_execution_search_filter_values(
-            "test-union", account_id, self.token, filter_names
+            "test-union", account_id, self.user_config.get("token"), filter_names
         )
 
     @staticmethod
@@ -523,7 +521,7 @@ class TestManager(Manager):
         configuration_body = {"overrideExecutions": override_executions}
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "PATCH",
             f"{TESTS_ENDPOINT}/{performance_test.test_id}",
             result_formatter=format_tests,
@@ -554,7 +552,7 @@ class TestManager(Manager):
             configuration, fc
         )
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "PATCH",
             f"{TESTS_ENDPOINT}/{test_id}",
             result_formatter=format_tests,
@@ -671,11 +669,10 @@ Hints:
     )
     async def tests(action: str, args: Dict[str, Any], ctx: Context) -> BaseResult:
         test_manager = TestManager(
-            runtime.auth.get_token(ctx),
             ctx,
             runtime.file_access,
             runtime.scope_resolver,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/user_manager.py
+++ b/tools/user_manager.py
@@ -31,8 +31,13 @@ from tools.utils import api_request, format_sanitized_traceback
 
 class UserManager(Manager):
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def read(self) -> BaseResult:
         return await api_request(
@@ -61,7 +66,11 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        user_manager = UserManager(runtime.auth.get_token(ctx), ctx)
+        user_manager = UserManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/user_manager.py
+++ b/tools/user_manager.py
@@ -20,7 +20,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, USER_ENDPOINT
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.user import format_users
 from models.manager import Manager
 from models.result import BaseResult
@@ -63,7 +63,7 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         user_manager = UserManager(ctx)
 
         async def _dispatch():

--- a/tools/user_manager.py
+++ b/tools/user_manager.py
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import httpx
 from mcp.server.fastmcp import Context
@@ -33,13 +33,12 @@ class UserManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def read(self) -> BaseResult:
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{USER_ENDPOINT}",
             result_formatter=format_users
@@ -64,10 +63,8 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        user_manager = UserManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        user_manager = UserManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/user_manager.py
+++ b/tools/user_manager.py
@@ -20,8 +20,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import TOOLS_PREFIX, USER_ENDPOINT
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.user import format_users
 from models.manager import Manager
 from models.result import BaseResult
@@ -33,15 +32,14 @@ class UserManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def read(self) -> BaseResult:
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{USER_ENDPOINT}",
             result_formatter=format_users
@@ -67,9 +65,8 @@ Hints:
     ) -> BaseResult:
 
         user_manager = UserManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -24,13 +24,14 @@ import sys
 import traceback
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional, Callable, Awaitable
+from typing import Any, Optional, Callable, Awaitable
 from importlib import resources
 from pathlib import Path
 
 import httpx
 from pydantic import BaseModel
 
+from config.auth import BZM_USER_CONFIG_STATE_ATTR
 from config.blazemeter import BZM_API_BASE_URL
 from config.security import validate_http_request_endpoint
 from config.token import BzmToken
@@ -127,9 +128,6 @@ class ConfirmMode(Enum):
     DELETE = "DELETE"  # Delete only
     CUD = "CUD"  # Create, Update, Delete
     DISABLE = "NONE"  # No confirmation
-
-
-_confirm_mode = ConfirmMode.DELETE
 
 
 class Operations(Enum):
@@ -270,18 +268,59 @@ class Confirmation(BaseModel):
     pass  # Empty model with no fields for simple accept/cancel without UI elements
 
 
-def register_confirm_mode(confirm_mode_value: ConfirmMode):
-    global _confirm_mode
-    _confirm_mode = confirm_mode_value
+def _to_confirm_mode(value: Any) -> ConfirmMode:
+    if isinstance(value, ConfirmMode):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().upper()
+        if normalized in ConfirmMode.__members__:
+            return ConfirmMode[normalized]
+        for mode in ConfirmMode:
+            if normalized == mode.value:
+                return mode
+    return ConfirmMode.DELETE
 
 
-def get_confirm_mode() -> ConfirmMode:
-    global _confirm_mode
-    return _confirm_mode
+def _get_ctx_user_config(ctx: Any) -> dict[str, Any] | None:
+    if ctx is None:
+        return None
+
+    user_config = getattr(ctx, "user_config", None)
+    if isinstance(user_config, dict):
+        return user_config
+
+    ctx_state = getattr(ctx, "state", None)
+    if ctx_state is not None:
+        state_config = getattr(ctx_state, "user_config", None)
+        if isinstance(state_config, dict):
+            return state_config
+
+    request = getattr(getattr(ctx, "request_context", None), "request", None)
+    if request is not None:
+        request_config = getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, None)
+        if isinstance(request_config, dict):
+            return request_config
+    return None
 
 
-def operation_need_confirmation(operation: Operations) -> bool:
-    confirm_mode = get_confirm_mode()
+def resolve_confirmation_mode(ctx: Any, manager_user_config: Any = None) -> ConfirmMode:
+    """
+    Resolve confirmation mode from runtime/user session context.
+
+    Precedence:
+    1) per-request/per-session context user config
+    2) manager-level user config (stdio startup config)
+    3) DELETE default
+    """
+    ctx_user_config = _get_ctx_user_config(ctx)
+    if isinstance(ctx_user_config, dict):
+        return _to_confirm_mode(ctx_user_config.get("confirmation_mode"))
+    if isinstance(manager_user_config, dict):
+        return _to_confirm_mode(manager_user_config.get("confirmation_mode"))
+    return ConfirmMode.DELETE
+
+
+def operation_need_confirmation(operation: Operations, confirm_mode: ConfirmMode) -> bool:
     if confirm_mode == ConfirmMode.DELETE and operation in [Operations.DELETE]:
         return True
     elif confirm_mode == ConfirmMode.CUD and operation in [Operations.CREATE, Operations.UPDATE, Operations.DELETE]:
@@ -301,7 +340,11 @@ def require_confirmation(operation: Operations = Operations.READ,
     def decorator(func: Callable[..., Awaitable]):
         @functools.wraps(func)
         async def wrapper(self, *args, **kwargs):
-            need_confirmation = operation_need_confirmation(operation)
+            confirm_mode = resolve_confirmation_mode(
+                getattr(self, "ctx", None),
+                getattr(self, "user_config", None),
+            )
+            need_confirmation = operation_need_confirmation(operation, confirm_mode)
             confirmed = True  # Run operation by default
             if need_confirmation:
                 try:

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -285,26 +285,16 @@ def _get_ctx_user_config(ctx: Any) -> dict[str, Any] | None:
     if ctx is None:
         return None
 
-    user_config = getattr(ctx, "user_config", None)
-    if isinstance(user_config, dict):
-        return user_config
-
-    ctx_state = getattr(ctx, "state", None)
-    if ctx_state is not None:
-        state_config = getattr(ctx_state, "user_config", None)
-        if isinstance(state_config, dict):
-            return state_config
-
     request_context = getattr(ctx, "request_context", None)
     context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
     if isinstance(context_config, dict):
         return context_config
 
     request = getattr(request_context, "request", None)
-    if request is not None:
-        request_config = getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, None)
-        if isinstance(request_config, dict):
-            return request_config
+    request_state = getattr(request, "state", None)
+    request_config = getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
+    if isinstance(request_config, dict):
+        return request_config
     return None
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -31,8 +31,8 @@ from pathlib import Path
 import httpx
 from pydantic import BaseModel
 
-from config.auth import BZM_USER_CONFIG_STATE_ATTR
 from config.blazemeter import BZM_API_BASE_URL
+from config.context_resolution import resolve_ctx_user_config
 from config.security import validate_http_request_endpoint
 from config.token import BzmToken
 from config.version import __version__
@@ -282,19 +282,9 @@ def _to_confirm_mode(value: Any) -> ConfirmMode:
 
 
 def _get_ctx_user_config(ctx: Any) -> dict[str, Any] | None:
-    if ctx is None:
-        return None
-
-    request_context = getattr(ctx, "request_context", None)
-    context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
-    if isinstance(context_config, dict):
-        return context_config
-
-    request = getattr(request_context, "request", None)
-    request_state = getattr(request, "state", None)
-    request_config = getattr(request_state, BZM_USER_CONFIG_STATE_ATTR, None)
-    if isinstance(request_config, dict):
-        return request_config
+    user_config = resolve_ctx_user_config(ctx)
+    if user_config:
+        return user_config
     return None
 
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -295,7 +295,12 @@ def _get_ctx_user_config(ctx: Any) -> dict[str, Any] | None:
         if isinstance(state_config, dict):
             return state_config
 
-    request = getattr(getattr(ctx, "request_context", None), "request", None)
+    request_context = getattr(ctx, "request_context", None)
+    context_config = getattr(request_context, BZM_USER_CONFIG_STATE_ATTR, None)
+    if isinstance(context_config, dict):
+        return context_config
+
+    request = getattr(request_context, "request", None)
     if request is not None:
         request_config = getattr(request.state, BZM_USER_CONFIG_STATE_ATTR, None)
         if isinstance(request_config, dict):

--- a/tools/workspace_manager.py
+++ b/tools/workspace_manager.py
@@ -20,7 +20,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import WORKSPACES_ENDPOINT, TOOLS_PREFIX
-from config.runtime import AppRuntime, build_user_config
+from config.runtime import AppRuntime
 from formatters.workspace import format_workspaces, format_workspaces_detailed, format_workspaces_locations
 from models.manager import Manager
 from models.result import BaseResult
@@ -141,7 +141,7 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        build_user_config(runtime, ctx)
+        runtime.configure_context(ctx)
         workspace_manager = WorkspaceManager(ctx)
 
         async def _dispatch():

--- a/tools/workspace_manager.py
+++ b/tools/workspace_manager.py
@@ -36,8 +36,13 @@ class WorkspaceManager(Manager):
     # the format_workspaces only expose minimum information to user
     # The read operation verify permissions and don't allow to share details.
 
-    def __init__(self, token: Optional[BzmToken], ctx: Context):
-        super().__init__(token, ctx)
+    def __init__(
+        self,
+        token: Optional[BzmToken],
+        ctx: Context,
+        user_config: Optional[dict[str, Any]] = None,
+    ):
+        super().__init__(token, ctx, user_config=user_config)
 
     async def read(self, workspace_id: Optional[int]) -> BaseResult:
         if not isinstance(workspace_id, int) or workspace_id < 1:
@@ -139,7 +144,11 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        workspace_manager = WorkspaceManager(runtime.auth.get_token(ctx), ctx)
+        workspace_manager = WorkspaceManager(
+            runtime.auth.get_token(ctx),
+            ctx,
+            user_config=runtime.user_config,
+        )
 
         async def _dispatch():
             match action:

--- a/tools/workspace_manager.py
+++ b/tools/workspace_manager.py
@@ -38,16 +38,15 @@ class WorkspaceManager(Manager):
     def __init__(
         self,
         ctx: Context,
-        user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(ctx, user_config=user_config)
+        super().__init__(ctx)
 
     async def read(self, workspace_id: Optional[int]) -> BaseResult:
         if not isinstance(workspace_id, int) or workspace_id < 1:
             return BaseResult(error="Missing or invalid required argument 'workspace_id'. Expected integer.")
 
         workspace_result = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{WORKSPACES_ENDPOINT}/{workspace_id}",
             result_formatter=format_workspaces_detailed
@@ -56,7 +55,7 @@ class WorkspaceManager(Manager):
             return workspace_result
         else:
             # Check if it's valid or allowed
-            account_result = await bridge.read_account(self.user_config.get("token"), self.ctx,
+            account_result = await bridge.read_account(self.token, self.ctx,
                                                        workspace_result.result[0].account_id)
             if account_result.error:
                 return account_result
@@ -70,7 +69,7 @@ class WorkspaceManager(Manager):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
+        account_data = await bridge.read_account(self.token, self.ctx, account_id)
         if account_data.error:
             return account_data
 
@@ -82,7 +81,7 @@ class WorkspaceManager(Manager):
         }
 
         return await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{WORKSPACES_ENDPOINT}",
             result_formatter=format_workspaces,
@@ -96,7 +95,7 @@ class WorkspaceManager(Manager):
             return BaseResult(error="Invalid argument 'purpose'. Expected non-empty string.")
 
         locations_result = await api_request(
-            self.user_config.get("token"),
+            self.token,
             "GET",
             f"{WORKSPACES_ENDPOINT}/{workspace_id}",
             result_formatter=format_workspaces_locations,
@@ -106,7 +105,7 @@ class WorkspaceManager(Manager):
             return locations_result
         else:
             # Check if it's valid or allowed
-            account_result = await bridge.read_account(self.user_config.get("token"), self.ctx,
+            account_result = await bridge.read_account(self.token, self.ctx,
                                                        locations_result.result[0]["account_id"])
             if account_result.error:
                 return account_result
@@ -142,10 +141,8 @@ Hints:
             ctx: Context = Field(description="Context object providing access to MCP capabilities")
     ) -> BaseResult:
 
-        workspace_manager = WorkspaceManager(
-            ctx,
-            user_config=build_user_config(runtime, ctx),
-        )
+        build_user_config(runtime, ctx)
+        workspace_manager = WorkspaceManager(ctx)
 
         async def _dispatch():
             match action:

--- a/tools/workspace_manager.py
+++ b/tools/workspace_manager.py
@@ -20,8 +20,7 @@ from mcp.server.fastmcp import Context
 from pydantic import Field
 
 from config.blazemeter import WORKSPACES_ENDPOINT, TOOLS_PREFIX
-from config.token import BzmToken
-from config.runtime import AppRuntime
+from config.runtime import AppRuntime, build_user_config
 from formatters.workspace import format_workspaces, format_workspaces_detailed, format_workspaces_locations
 from models.manager import Manager
 from models.result import BaseResult
@@ -38,18 +37,17 @@ class WorkspaceManager(Manager):
 
     def __init__(
         self,
-        token: Optional[BzmToken],
         ctx: Context,
         user_config: Optional[dict[str, Any]] = None,
     ):
-        super().__init__(token, ctx, user_config=user_config)
+        super().__init__(ctx, user_config=user_config)
 
     async def read(self, workspace_id: Optional[int]) -> BaseResult:
         if not isinstance(workspace_id, int) or workspace_id < 1:
             return BaseResult(error="Missing or invalid required argument 'workspace_id'. Expected integer.")
 
         workspace_result = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{WORKSPACES_ENDPOINT}/{workspace_id}",
             result_formatter=format_workspaces_detailed
@@ -58,7 +56,7 @@ class WorkspaceManager(Manager):
             return workspace_result
         else:
             # Check if it's valid or allowed
-            account_result = await bridge.read_account(self.token, self.ctx,
+            account_result = await bridge.read_account(self.user_config.get("token"), self.ctx,
                                                        workspace_result.result[0].account_id)
             if account_result.error:
                 return account_result
@@ -72,7 +70,7 @@ class WorkspaceManager(Manager):
             return BaseResult(error="Invalid arguments 'limit'/'offset'. Expected integers.")
 
         # Check if it's valid or allowed
-        account_data = await bridge.read_account(self.token, self.ctx, account_id)
+        account_data = await bridge.read_account(self.user_config.get("token"), self.ctx, account_id)
         if account_data.error:
             return account_data
 
@@ -84,7 +82,7 @@ class WorkspaceManager(Manager):
         }
 
         return await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{WORKSPACES_ENDPOINT}",
             result_formatter=format_workspaces,
@@ -98,7 +96,7 @@ class WorkspaceManager(Manager):
             return BaseResult(error="Invalid argument 'purpose'. Expected non-empty string.")
 
         locations_result = await api_request(
-            self.token,
+            self.user_config.get("token"),
             "GET",
             f"{WORKSPACES_ENDPOINT}/{workspace_id}",
             result_formatter=format_workspaces_locations,
@@ -108,7 +106,7 @@ class WorkspaceManager(Manager):
             return locations_result
         else:
             # Check if it's valid or allowed
-            account_result = await bridge.read_account(self.token, self.ctx,
+            account_result = await bridge.read_account(self.user_config.get("token"), self.ctx,
                                                        locations_result.result[0]["account_id"])
             if account_result.error:
                 return account_result
@@ -145,9 +143,8 @@ Hints:
     ) -> BaseResult:
 
         workspace_manager = WorkspaceManager(
-            runtime.auth.get_token(ctx),
             ctx,
-            user_config=runtime.user_config,
+            user_config=build_user_config(runtime, ctx),
         )
 
         async def _dispatch():


### PR DESCRIPTION
This branch migrates confirmation behavior from a process-wide global state to a per-session/per-context model.
In HTTP mode, Confirmation-Mode is read from request headers and reused by mcp-session-id; in stdio mode, the confirmation setting is injected via runtime.user_config, so require_confirmation applies DELETE/CUD/DISABLE consistently per invocation without relying on shared global flags.